### PR TITLE
Fix interactive create without --root

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ kickstart create
 ```
 
 This will launch an interactive wizard to help you create your project.
+The wizard will prompt for the project type, name, root directory and other options.
 
 ### Shell Completion
 Enable shell completion for better CLI experience:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -31,7 +31,7 @@ def completion(shell: str = typer.Argument(..., help="bash | zsh | fish | powers
 def create(
     type: str = typer.Argument(None),
     name: str = typer.Argument(None),
-    root: str = typer.Option(..., "--root", "-r", help="Root directory where the project will be created"),
+    root: str = typer.Option(None, "--root", "-r", help="Root directory where the project will be created"),
     lang: str = typer.Option("python", "--lang", "-l"),
     gh: bool = typer.Option(False, "--gh", help="Create GitHub repo"),
     helm: bool = typer.Option(False, "--helm", help="Add Helm scaffolding (services or mono only)")

--- a/tests/unit/cli/test_interactive_create.py
+++ b/tests/unit/cli/test_interactive_create.py
@@ -1,0 +1,22 @@
+from typer.testing import CliRunner
+from src.cli.main import app
+import src.cli.main as cli_main
+
+
+def test_interactive_create_service(tmp_path, monkeypatch):
+    runner = CliRunner()
+    recorded = {}
+
+    def fake_create_service(name, lang, gh, config, helm=False, root=None):
+        recorded['name'] = name
+        recorded['root'] = root
+        recorded['lang'] = lang
+
+    monkeypatch.setattr(cli_main, 'create_service', fake_create_service)
+    monkeypatch.setattr(cli_main, 'load_config', lambda: {})
+
+    inputs = f"service\nmy-svc\n{tmp_path}\npython\nn\nn\n"
+    result = runner.invoke(app, ['create'], input=inputs)
+    assert result.exit_code == 0
+    assert recorded['name'] == 'my-svc'
+    assert recorded['root'] == str(tmp_path)


### PR DESCRIPTION
## Summary
- allow `kickstart create` without --root for interactive mode
- document interactive wizard behaviour
- test interactive create flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444f3fccf08331b91acede77fe0609