### PR TITLE
Use CliRunner in CLI help test

### DIFF
--- a/tests/integration/test_cli_sanity.py
+++ b/tests/integration/test_cli_sanity.py
@@ -1,11 +1,9 @@
-import subprocess
+from typer.testing import CliRunner
+from src.cli.main import app
 
 def test_help_output():
-    result = subprocess.run(
-        ["poetry", "run", "kickstart", "--help"],
-        capture_output=True,
-        text=True
-    )
+    result = CliRunner().invoke(app, ["--help"])
+    assert result.exit_code == 0
     assert "Kickstart" in result.stdout
     assert "create" in result.stdout
 


### PR DESCRIPTION
## Summary
- speed up CLI sanity check with Typer's testing utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684455ded7488331b370247636ed7926