### PR TITLE
Fix style closure in CLI error message

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -62,4 +62,4 @@ def create(
     elif type == "mono":
         create_monorepo(name, config, helm=helm, root=root)
     else:
-        print(f"[bold red]❌ Type '{type}' not supported.")
+        print(f"[bold red]❌ Type '{type}' not supported.[/]")


### PR DESCRIPTION
## Summary
- close Rich style tag for unsupported `create` command types

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_684455e9315c83319235cfd3a5873204