### PR TITLE
Add spec parser module and tests

### DIFF
--- a/kickstart.py
+++ b/kickstart.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 
 from src.cli.main import app
 

--- a/src/spec/parser.py
+++ b/src/spec/parser.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+
+def _parse_bool(value: str) -> bool:
+    return value.strip().lower() in {"true", "yes", "1"}
+
+
+@dataclass
+class Component:
+    type: str
+    name: str
+    lang: Optional[str] = None
+    root: Optional[str] = None
+    helm: bool = False
+
+
+def parse(path: Path | str) -> List[Component]:
+    """Parse a Markdown specification file into a list of Components."""
+    lines = Path(path).read_text().splitlines()
+    table_lines = [line.strip() for line in lines if line.strip().startswith("|") and line.strip().endswith("|")]
+    if not table_lines:
+        return []
+
+    headers = [h.strip().lower() for h in table_lines[0].strip("|").split("|")]
+    # skip header and separator line if present
+    data_lines = [line for line in table_lines[1:] if not set(line.strip()) <= {"|", "-", " "}]
+
+    components: List[Component] = []
+    for line in data_lines:
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) != len(headers):
+            continue
+        row = dict(zip(headers, cells))
+        comp = Component(
+            type=row.get("type", ""),
+            name=row.get("name", ""),
+            lang=row.get("lang") or None,
+            root=row.get("root") or None,
+            helm=_parse_bool(row.get("helm", "")),
+        )
+        components.append(comp)
+    return components

--- a/tests/unit/spec/test_parser.py
+++ b/tests/unit/spec/test_parser.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from src.spec.parser import parse, Component
+
+
+def test_parse_markdown_table(tmp_path: Path):
+    md = tmp_path / "spec.md"
+    md.write_text(
+        """
+| type | name | lang | root | helm |
+| ---- | ---- | ---- | ---- | ---- |
+| service | auth | python | services | true |
+| lib | utils | rust | libs | false |
+| frontend | web | react | apps | |
+"""
+    )
+    comps = parse(md)
+    assert comps == [
+        Component(type="service", name="auth", lang="python", root="services", helm=True),
+        Component(type="lib", name="utils", lang="rust", root="libs", helm=False),
+        Component(type="frontend", name="web", lang="react", root="apps", helm=False),
+    ]
+
+
+def test_parse_no_table(tmp_path: Path):
+    md = tmp_path / "empty.md"
+    md.write_text("# Nothing here")
+    assert parse(md) == []


### PR DESCRIPTION
## Summary
- add `src/spec/parser.py` to parse Markdown component tables
- add unit tests for the parser
- make `kickstart.py` executable for integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844613dc4f88331bd832a61f37b06b0