### PR TITLE
Expose generator functions via api module

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,44 @@
+"""Public API for Kickstart generators."""
+
+from src.generators.service import ServiceGenerator
+from src.generators.frontend import FrontendGenerator
+from src.generators.lib import LibraryGenerator, CLIGenerator
+from src.generators.monorepo import MonorepoGenerator
+
+__all__ = [
+    "create_service",
+    "create_frontend",
+    "create_lib",
+    "create_cli",
+    "create_monorepo",
+]
+
+
+def create_service(name: str, lang: str, gh: bool, config: dict, *, helm: bool = False, root: str | None = None) -> None:
+    """Create a backend service project."""
+    generator = ServiceGenerator(name, lang, gh, config, helm, root)
+    generator.create()
+
+
+def create_frontend(name: str, gh: bool, config: dict, *, root: str | None = None) -> None:
+    """Create a frontend application."""
+    generator = FrontendGenerator(name, gh, config, root)
+    generator.create()
+
+
+def create_lib(name: str, lang: str, gh: bool, config: dict, *, root: str | None = None) -> None:
+    """Create a library project."""
+    generator = LibraryGenerator(name, lang, gh, config, root)
+    generator.create()
+
+
+def create_cli(name: str, lang: str, gh: bool, config: dict, *, root: str | None = None) -> None:
+    """Create a CLI application."""
+    generator = CLIGenerator(name, lang, gh, config, root)
+    generator.create()
+
+
+def create_monorepo(name: str, gh: bool, config: dict, *, helm: bool = False, root: str | None = None) -> None:
+    """Create an infrastructure monorepo."""
+    generator = MonorepoGenerator(name, gh, config, helm, root)
+    generator.create()

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -5,10 +5,13 @@ from typing import Optional
 
 from src import __version__
 from src.utils.config import load_config
-from src.generators.service import create_service
-from src.generators.frontend import create_frontend
-from src.generators.lib import create_lib, create_cli
-from src.generators.monorepo import create_monorepo
+from src.api import (
+    create_service,
+    create_frontend,
+    create_lib,
+    create_cli,
+    create_monorepo,
+)
 from src.utils.updater import check_for_update
 
 app = typer.Typer(help="Kickstart: Full-stack project scaffolding CLI")

--- a/src/generators/frontend.py
+++ b/src/generators/frontend.py
@@ -36,8 +36,3 @@ class FrontendGenerator(BaseGenerator):
         if self.gh:
             create_repo(self.name)
 
-def create_frontend(name: str, gh: bool, config: dict, root: str = None):
-    """Factory function for backward compatibility"""
-    generator = FrontendGenerator(name, gh, config, root)
-    generator.create()
-

--- a/src/generators/lib.py
+++ b/src/generators/lib.py
@@ -73,13 +73,3 @@ class CLIGenerator(LibraryGenerator):
         if self.gh:
             create_repo(self.name)
 
-def create_lib(name: str, lang: str, gh: bool, config: dict, root: str = None):
-    """Factory function for backward compatibility"""
-    generator = LibraryGenerator(name, lang, gh, config, root)
-    generator.create()
-
-def create_cli(name: str, lang: str, gh: bool, config: dict, root: str = None):
-    """Factory function for backward compatibility"""
-    generator = CLIGenerator(name, lang, gh, config, root)
-    generator.create()
-

--- a/src/generators/monorepo.py
+++ b/src/generators/monorepo.py
@@ -70,8 +70,3 @@ class MonorepoGenerator(BaseGenerator):
         self.write_template("infra/k8s/base/deployment.yaml", "kustomize/deployment.yaml")
         self.write_template("infra/k8s/base/service.yaml", "kustomize/service.yaml")
 
-def create_monorepo(name: str, gh: bool, config: dict, helm: bool = False, root: str = None):
-    """Factory function for backward compatibility"""
-    generator = MonorepoGenerator(name, gh, config, helm, root)
-    generator.create()
-

--- a/src/generators/service.py
+++ b/src/generators/service.py
@@ -141,8 +141,4 @@ func main() {
 
         success("Helm chart scaffolded")
 
-def create_service(name: str, lang: str, gh: bool, config: dict, helm: bool = False, root: str = None):
-    """Factory function for backward compatibility"""
-    generator = ServiceGenerator(name, lang, gh, config, helm, root)
-    generator.create()
 


### PR DESCRIPTION
## Summary
- move generator factory functions to new `src/api.py`
- update CLI to import generators from `src.api`
- clean up generator modules

## Testing
- `pip install -e .`
- `pip install click==8.1.7`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac207d9408331bf5224cb6ea8abd6