### PR TITLE
Refactor generator setup helpers

### DIFF
--- a/src/generators/base.py
+++ b/src/generators/base.py
@@ -42,4 +42,13 @@ class BaseGenerator:
 
     def get_common_vars(self) -> Dict[str, str]:
         """Get common template variables."""
-        return {"service_name": self.name} 
+        return {"service_name": self.name}
+
+    def init_basic_structure(self, dirs: List[str]) -> None:
+        """Create the base directory structure for a new project."""
+        self.create_directories(dirs)
+
+    def create_architecture_docs(self, title: str) -> None:
+        """Create the architecture documentation directory and README."""
+        self.create_directories(["architecture"])
+        self.write_content("architecture/README.md", f"# {title}\n")

--- a/src/generators/frontend.py
+++ b/src/generators/frontend.py
@@ -14,7 +14,7 @@ class FrontendGenerator(BaseGenerator):
             return
 
         # Create project structure
-        self.create_directories([
+        self.init_basic_structure([
             "src",
             "public",
             "tests",
@@ -29,7 +29,7 @@ class FrontendGenerator(BaseGenerator):
         self.write_template("package.json", "package.json.tpl")
         
         # Write direct content
-        self.write_content("architecture/README.md", f"# {self.name} Frontend Docs\n")
+        self.create_architecture_docs(f"{self.name} Frontend Docs")
 
         self.log_success(f"Frontend app '{self.name}' created successfully in '{self.project}'!")
 

--- a/src/generators/lib.py
+++ b/src/generators/lib.py
@@ -15,7 +15,7 @@ class LibraryGenerator(BaseGenerator):
             return
 
         # Create project structure
-        self.create_directories([
+        self.init_basic_structure([
             "src",
             "tests",
             "architecture"
@@ -27,7 +27,7 @@ class LibraryGenerator(BaseGenerator):
         self.write_template("README.md", f"{self.lang}/README.md.tpl")
         
         # Write direct content
-        self.write_content("architecture/README.md", f"# {self.name} Library Docs\n")
+        self.create_architecture_docs(f"{self.name} Library Docs")
 
         # Language-specific files
         if self.lang == "python":
@@ -46,7 +46,7 @@ class CLIGenerator(LibraryGenerator):
             return
 
         # Create project structure
-        self.create_directories([
+        self.init_basic_structure([
             "src",
             "tests",
             "architecture"
@@ -58,7 +58,7 @@ class CLIGenerator(LibraryGenerator):
         self.write_template("README.md", f"{self.lang}/README.md.tpl")
         
         # Write direct content
-        self.write_content("architecture/README.md", f"# {self.name} CLI Docs\n")
+        self.create_architecture_docs(f"{self.name} CLI Docs")
 
         # Language-specific files
         if self.lang == "python":

--- a/src/generators/monorepo.py
+++ b/src/generators/monorepo.py
@@ -15,7 +15,7 @@ class MonorepoGenerator(BaseGenerator):
             return
 
         # Create infrastructure directories
-        self.create_directories([
+        self.init_basic_structure([
             "infra/docker",
             "infra/terraform/modules/example_module",
             *[f"infra/terraform/env/{env}" for env in ["dev", "staging", "prod"]],
@@ -42,7 +42,7 @@ class MonorepoGenerator(BaseGenerator):
             self.write_template(f".github/workflows/{wf}", wf)
 
         # Write documentation and configuration
-        self.write_content("architecture/README.md", f"# {self.name} Deployment Infra Docs\n")
+        self.create_architecture_docs(f"{self.name} Deployment Infra Docs")
         self.write_template("Makefile", "Makefile.tpl", monorepo_name=self.name)
         self.write_template("README.md", "README.md.tpl", monorepo_name=self.name)
 

--- a/src/generators/service.py
+++ b/src/generators/service.py
@@ -21,7 +21,7 @@ class ServiceGenerator(BaseGenerator):
             return
 
         # Create project structure
-        self.create_directories([
+        self.init_basic_structure([
             "src",
             "src/api",
             "src/model",
@@ -38,7 +38,7 @@ class ServiceGenerator(BaseGenerator):
         self.write_template("Makefile", f"{self.lang}/Makefile.tpl")
         
         # Write direct content
-        self.write_content("architecture/README.md", f"# {self.name} Architecture Notes\n")
+        self.create_architecture_docs(f"{self.name} Architecture Notes")
         self.write_content(".env.example", "EXAMPLE_ENV_VAR=value\n")
 
         # Language-specific files and structure

--- a/tests/unit/generators/test_base.py
+++ b/tests/unit/generators/test_base.py
@@ -37,6 +37,19 @@ def test_create_directories(base_generator, tmp_path):
         assert (tmp_path / "dir1").exists()
         assert (tmp_path / "dir2/subdir").exists()
 
+def test_init_basic_structure(base_generator, tmp_path):
+    with patch.object(base_generator, 'project', tmp_path):
+        base_generator.init_basic_structure(["foo", "bar"])
+        assert (tmp_path / "foo").exists()
+        assert (tmp_path / "bar").exists()
+
+def test_create_architecture_docs(base_generator, tmp_path):
+    with patch.object(base_generator, 'project', tmp_path):
+        base_generator.create_architecture_docs("My Docs")
+        arch = tmp_path / "architecture/README.md"
+        assert arch.exists()
+        assert arch.read_text() == "# My Docs\n"
+
 @patch('src.generators.base.write_file')
 def test_write_template(mock_write_file, base_generator, tmp_path):
     template_path = tmp_path / "template.txt"


### PR DESCRIPTION
## Summary
- add `init_basic_structure` and `create_architecture_docs` helpers
- use helpers across all generators
- test helpers in generator unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac421aae083318e2e402b52fce58d