### PR TITLE
Update integration tests to use kickstart.py

### DIFF
--- a/tests/integration/test_cli_sanity.py
+++ b/tests/integration/test_cli_sanity.py
@@ -1,9 +1,22 @@
-from typer.testing import CliRunner
-from src.cli.main import app
+import subprocess
+import sys
+import os
+from pathlib import Path
 
-def test_help_output():
-    result = CliRunner().invoke(app, ["--help"], prog_name="kickstart")
-    assert result.exit_code == 0
+def test_help_output(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root)
+
+    result = subprocess.run(
+        [sys.executable, str(repo_root / "kickstart.py"), "--help"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0
     assert "Kickstart" in result.stdout
     assert "create" in result.stdout
 

--- a/tests/integration/test_create_frontend.py
+++ b/tests/integration/test_create_frontend.py
@@ -1,18 +1,21 @@
 import subprocess
+import sys
 from pathlib import Path
 import tempfile
-import shutil
+import os
 
 def test_create_frontend():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        kickstart_bin = shutil.which("kickstart")
-        assert kickstart_bin is not None, "kickstart binary not found in PATH"
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(repo_root)
 
         subprocess.run(
-            [kickstart_bin, "create", "frontend", "my-app", "--root", str(tmp)],
+            [sys.executable, str(repo_root / "kickstart.py"), "create", "frontend", "my-app", "--root", str(tmp)],
             cwd=tmp,
-            check=True
+            check=True,
+            env=env,
         )
 
         app = tmp / "my-app"
@@ -24,17 +27,19 @@ def test_create_frontend():
 def test_create_frontend_with_root():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        kickstart_bin = shutil.which("kickstart")
-        assert kickstart_bin is not None, "kickstart binary not found in PATH"
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(repo_root)
 
         # Create a custom root directory
         custom_root = tmp / "custom-root"
         custom_root.mkdir()
 
         subprocess.run(
-            [kickstart_bin, "create", "frontend", "my-app", "--root", str(custom_root)],
+            [sys.executable, str(repo_root / "kickstart.py"), "create", "frontend", "my-app", "--root", str(custom_root)],
             cwd=tmp,
-            check=True
+            check=True,
+            env=env,
         )
 
         app = custom_root / "my-app"

--- a/tests/integration/test_create_lib.py
+++ b/tests/integration/test_create_lib.py
@@ -1,18 +1,21 @@
 import subprocess
+import sys
 from pathlib import Path
 import tempfile
-import shutil
+import os
 
 def test_create_python_lib():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        kickstart_bin = shutil.which("kickstart")
-        assert kickstart_bin is not None, "kickstart binary not found in PATH"
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(repo_root)
 
         subprocess.run(
-            [kickstart_bin, "create", "lib", "my-lib", "--lang", "python", "--root", str(tmp)],
+            [sys.executable, str(repo_root / "kickstart.py"), "create", "lib", "my-lib", "--lang", "python", "--root", str(tmp)],
             cwd=tmp,
-            check=True
+            check=True,
+            env=env,
         )
 
         lib = tmp / "my-lib"
@@ -23,17 +26,19 @@ def test_create_python_lib():
 def test_create_python_lib_with_root():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        kickstart_bin = shutil.which("kickstart")
-        assert kickstart_bin is not None, "kickstart binary not found in PATH"
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(repo_root)
 
         # Create a custom root directory
         custom_root = tmp / "custom-root"
         custom_root.mkdir()
 
         subprocess.run(
-            [kickstart_bin, "create", "lib", "my-lib", "--lang", "python", "--root", str(custom_root)],
+            [sys.executable, str(repo_root / "kickstart.py"), "create", "lib", "my-lib", "--lang", "python", "--root", str(custom_root)],
             cwd=tmp,
-            check=True
+            check=True,
+            env=env,
         )
 
         lib = custom_root / "my-lib"

--- a/tests/integration/test_create_mono.py
+++ b/tests/integration/test_create_mono.py
@@ -1,18 +1,21 @@
 import tempfile
 from pathlib import Path
 import subprocess
-import shutil
+import sys
+import os
 
 def test_create_monorepo_kustomize():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        kickstart_bin = shutil.which("kickstart")
-        assert kickstart_bin is not None
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(repo_root)
 
         subprocess.run(
-            [kickstart_bin, "create", "mono", "infra-stack", "--root", str(tmp)],
+            [sys.executable, str(repo_root / "kickstart.py"), "create", "mono", "infra-stack", "--root", str(tmp)],
             cwd=tmp,
-            check=True
+            check=True,
+            env=env,
         )
 
         base = tmp / "infra-stack"
@@ -22,17 +25,19 @@ def test_create_monorepo_kustomize():
 def test_create_monorepo_kustomize_with_root():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        kickstart_bin = shutil.which("kickstart")
-        assert kickstart_bin is not None
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(repo_root)
 
         # Create a custom root directory
         custom_root = tmp / "custom-root"
         custom_root.mkdir()
 
         subprocess.run(
-            [kickstart_bin, "create", "mono", "infra-stack", "--root", str(custom_root)],
+            [sys.executable, str(repo_root / "kickstart.py"), "create", "mono", "infra-stack", "--root", str(custom_root)],
             cwd=tmp,
-            check=True
+            check=True,
+            env=env,
         )
 
         base = custom_root / "infra-stack"

--- a/tests/integration/test_create_service.py
+++ b/tests/integration/test_create_service.py
@@ -1,18 +1,21 @@
 import subprocess
+import sys
 from pathlib import Path
 import tempfile
-import shutil
+import os
 
 def test_create_python_service():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        kickstart_bin = shutil.which("kickstart")
-        assert kickstart_bin is not None, "kickstart binary not found in PATH"
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(repo_root)
 
         subprocess.run(
-            [kickstart_bin, "create", "service", "hello-api", "--lang", "python", "--root", str(tmp)],
+            [sys.executable, str(repo_root / "kickstart.py"), "create", "service", "hello-api", "--lang", "python", "--root", str(tmp)],
             cwd=tmp,
-            check=True
+            check=True,
+            env=env,
         )
 
         svc = tmp / "hello-api"
@@ -23,17 +26,19 @@ def test_create_python_service():
 def test_create_python_service_with_root():
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
-        kickstart_bin = shutil.which("kickstart")
-        assert kickstart_bin is not None, "kickstart binary not found in PATH"
+        repo_root = Path(__file__).resolve().parents[2]
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(repo_root)
 
         # Create a custom root directory
         custom_root = tmp / "custom-root"
         custom_root.mkdir()
 
         subprocess.run(
-            [kickstart_bin, "create", "service", "hello-api", "--lang", "python", "--root", str(custom_root)],
+            [sys.executable, str(repo_root / "kickstart.py"), "create", "service", "hello-api", "--lang", "python", "--root", str(custom_root)],
             cwd=tmp,
-            check=True
+            check=True,
+            env=env,
         )
 
         svc = custom_root / "hello-api"


### PR DESCRIPTION
## Summary
- invoke CLI via `sys.executable` and `kickstart.py`
- drop `shutil.which` lookups
- add `PYTHONPATH` when running subprocesses

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*

------
https://chatgpt.com/codex/tasks/task_e_684ac418491c8331b8456722c301d535