### PR TITLE
Warn on GitHub repo creation failure

### DIFF
--- a/src/generators/mixins.py
+++ b/src/generators/mixins.py
@@ -1,6 +1,7 @@
 """Mixins for common generator functionality."""
 
 from src.utils.github import create_repo
+from src.utils.logger import warn
 
 
 class GitHubMixin:
@@ -13,7 +14,9 @@ class GitHubMixin:
     def create_github_repo_if_requested(self) -> None:
         """Create GitHub repository if the gh flag is set."""
         if hasattr(self, 'gh') and self.gh and hasattr(self, 'name'):
-            create_repo(self.name)
+            created = create_repo(self.name)
+            if not created:
+                warn(f"Failed to create GitHub repository '{self.name}'")
 
 
 class CommonTemplatesMixin:

--- a/src/generators/mixins.py
+++ b/src/generators/mixins.py
@@ -11,12 +11,17 @@ class GitHubMixin:
         super().__init__(*args, **kwargs)
         # Expect gh and name attributes to be set by the concrete class
     
-    def create_github_repo_if_requested(self) -> None:
-        """Create GitHub repository if the gh flag is set."""
+    def create_github_repo_if_requested(self) -> bool:
+        """Create GitHub repository if the gh flag is set.
+
+        Returns ``True`` if the repository was created, ``False`` otherwise.
+        """
         if hasattr(self, 'gh') and self.gh and hasattr(self, 'name'):
             created = create_repo(self.name)
             if not created:
                 warn(f"Failed to create GitHub repository '{self.name}'")
+            return created
+        return False
 
 
 class CommonTemplatesMixin:

--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -37,6 +37,22 @@ def test_mixin_warns_on_repo_creation_failure():
     dummy = Dummy()
     with patch("src.generators.mixins.create_repo", return_value=False) as mock_create, \
          patch("src.generators.mixins.warn") as mock_warn:
-        dummy.create_github_repo_if_requested()
+        result = dummy.create_github_repo_if_requested()
+        assert result is False
         mock_create.assert_called_once_with("dummy")
         mock_warn.assert_called_once_with("Failed to create GitHub repository 'dummy'")
+
+
+def test_mixin_no_warn_on_repo_creation_success():
+    class Dummy(GitHubMixin):
+        def __init__(self):
+            self.gh = True
+            self.name = "dummy"
+
+    dummy = Dummy()
+    with patch("src.generators.mixins.create_repo", return_value=True) as mock_create, \
+         patch("src.generators.mixins.warn") as mock_warn:
+        result = dummy.create_github_repo_if_requested()
+        assert result is True
+        mock_create.assert_called_once_with("dummy")
+        mock_warn.assert_not_called()

--- a/tests/unit/utils/test_github.py
+++ b/tests/unit/utils/test_github.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch, MagicMock
 
 from src.utils.github import create_repo
+from src.generators.mixins import GitHubMixin
 
 
 def test_create_repo_no_token():
@@ -25,3 +26,17 @@ def test_create_repo_failure():
         mock_post.return_value = mock_resp
         assert create_repo("bad") is False
         mock_post.assert_called_once()
+
+
+def test_mixin_warns_on_repo_creation_failure():
+    class Dummy(GitHubMixin):
+        def __init__(self):
+            self.gh = True
+            self.name = "dummy"
+
+    dummy = Dummy()
+    with patch("src.generators.mixins.create_repo", return_value=False) as mock_create, \
+         patch("src.generators.mixins.warn") as mock_warn:
+        dummy.create_github_repo_if_requested()
+        mock_create.assert_called_once_with("dummy")
+        mock_warn.assert_called_once_with("Failed to create GitHub repository 'dummy'")


### PR DESCRIPTION
## Summary
- log a warning when GitHub repository creation fails
- test that GitHubMixin surfaces the failure

## Testing
- `PYTHONPATH=. pytest tests/unit/utils/test_github.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68952c207ea48331a11175dd0fa8f4d0