### PR TITLE
Replace print statements with structured logging

### DIFF
--- a/src/utils/codegen.py
+++ b/src/utils/codegen.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 from pathlib import Path
 
-
+from .logger import success
 @dataclass
 class DatabaseColumn:
     """Represents a database column."""
@@ -457,7 +457,7 @@ pub use pg_dao::*;
 pub use mock_dao::*;
 ''')
     
-    print(f"Generated DAO structure for {len(tables)} tables in {output_dir}")
+    success(f"Generated DAO structure for {len(tables)} tables in {output_dir}")
 
 
 class CppDAOGenerator:
@@ -797,12 +797,12 @@ type {table.struct_name} struct {{
 
 // {table.struct_name}Create represents the data needed to create a {table.name}
 type {table.struct_name}Create struct {{
-{chr(10).join([f"\t{(''.join(word.capitalize() for word in col.name.split('_')))} {col.go_type} `json:\"{col.name}\"`" for col in table.columns if not col.primary_key])}
+  {chr(10).join([f'{chr(9)}{("".join(word.capitalize() for word in col.name.split("_")))} {col.go_type} `json:"{col.name}"`' for col in table.columns if not col.primary_key])}
 }}
 
 // {table.struct_name}Update represents the data that can be updated for a {table.name}
 type {table.struct_name}Update struct {{
-{chr(10).join([f"\t{(''.join(word.capitalize() for word in col.name.split('_')))} *{col.go_type.lstrip('*')} `json:\"{col.name},omitempty\"`" for col in table.columns if not col.primary_key])}
+  {chr(10).join([f'{chr(9)}{("".join(word.capitalize() for word in col.name.split("_")))} *{col.go_type.lstrip("*")} `json:"{col.name},omitempty"`' for col in table.columns if not col.primary_key])}
 }}
 '''.strip()
     
@@ -1029,4 +1029,6 @@ __all__ = [
             with open(output_path / f"pg_{table.name}_dao.go", 'w') as f:
                 f.write(generator.generate_pg_dao_impl(table))
     
-    print(f"Generated {language.upper()} DAO structure for {len(tables)} tables in {output_dir}")
+    success(
+        f"Generated {language.upper()} DAO structure for {len(tables)} tables in {output_dir}"
+    )

--- a/src/utils/updater.py
+++ b/src/utils/updater.py
@@ -3,12 +3,13 @@ import shutil
 import requests
 from pathlib import Path
 from src import __version__
+from .logger import info, success, error
 
 REPO = "woud420/kickstart"
 RELEASE_URL = f"https://api.github.com/repos/{REPO}/releases/latest"
 
 def check_for_update():
-    print(f"[cyan]Checking for updates (current version: {__version__})...")
+    info(f"Checking for updates (current version: {__version__})...")
 
     try:
         r = requests.get(RELEASE_URL, timeout=5)
@@ -20,10 +21,10 @@ def check_for_update():
                             if asset["name"] == "kickstart")
 
         if latest == __version__:
-            print("[green]✅ You're already up to date.")
+            success("You're already up to date")
             return
 
-        print(f"[yellow]⬆ New version available: {latest} — downloading...")
+        info(f"New version available: {latest}; downloading...")
 
         bin_path = Path(sys.argv[0]).resolve()
         backup = bin_path.with_suffix(".bak")
@@ -36,7 +37,7 @@ def check_for_update():
                 shutil.copyfileobj(r.raw, f)
 
         bin_path.chmod(0o755)
-        print(f"[green]✔ Updated successfully to {latest}! Backup saved to {backup}")
+        success(f"Updated successfully to {latest}; backup saved to {backup}")
 
     except Exception as e:
-        print(f"[red]✖ Update failed: {e}")
+        error(f"Update failed: {e}")


### PR DESCRIPTION
## Summary
- use logger utilities in `codegen` and `updater` instead of raw prints
- fix Go code generation strings to avoid invalid f-string backslashes

## Testing
- `PYTHONPATH=. pytest -q --maxfail=1` *(fails: FileNotFoundError: [Errno 2] No such file or directory: '/workspace/kickstart/src/templates/python/README.md.tpl')*

------
https://chatgpt.com/codex/tasks/task_e_6895344f2abc833191738e11527db04d