### PR TITLE
Ensure UTF-8 encoding in filesystem utilities

### DIFF
--- a/src/utils/fs.py
+++ b/src/utils/fs.py
@@ -1,9 +1,17 @@
 from pathlib import Path
 import re
 
+
 def write_file(path: Path, template: Path | str, **vars):
+    """Write ``path`` from a template using UTF-8 encoding.
+
+    Templates can be provided as a :class:`~pathlib.Path` or a string. When a
+    path is supplied, the file is read as UTF-8 and ``{{INCLUDE:filename}}``
+    directives within the template are processed. The resulting content is
+    written to ``path`` using UTF-8.
+    """
     if isinstance(template, Path):
-        content = template.read_text()
+        content = template.read_text(encoding="utf-8")
     else:
         content = template
 
@@ -15,10 +23,11 @@ def write_file(path: Path, template: Path | str, **vars):
         content = content.replace(f"{{{{{key.upper()}}}}}", str(value))
 
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content)
+    path.write_text(content, encoding="utf-8")
+
 
 def _process_includes(content: str, template_path: Path | None, **vars) -> str:
-    """Process {{INCLUDE:filename}} directives in templates."""
+    """Process ``{{INCLUDE:filename}}`` directives, reading files as UTF-8."""
     if template_path is None:
         return content
         
@@ -35,7 +44,7 @@ def _process_includes(content: str, template_path: Path | None, **vars) -> str:
         for include_dir in [shared_dir, template_dir]:
             include_path = include_dir / include_file
             if include_path.exists():
-                include_content = include_path.read_text()
+                include_content = include_path.read_text(encoding="utf-8")
                 # Recursively process includes in the included file
                 return _process_includes(include_content, include_path, **vars)
         
@@ -44,7 +53,7 @@ def _process_includes(content: str, template_path: Path | None, **vars) -> str:
     return re.sub(include_pattern, replace_include, content)
 
 def compose_template(parts: list[str], template_dir: Path, **vars) -> str:
-    """Compose a template from multiple parts."""
+    """Compose a template from multiple parts, reading each as UTF-8."""
     shared_dir = template_dir.parent / "_shared"
     content_parts = []
     
@@ -53,7 +62,7 @@ def compose_template(parts: list[str], template_dir: Path, **vars) -> str:
         for part_dir in [shared_dir, template_dir]:
             part_path = part_dir / f"{part_name}.tpl"
             if part_path.exists():
-                part_content = part_path.read_text()
+                part_content = part_path.read_text(encoding="utf-8")
                 # Process includes within each part
                 part_content = _process_includes(part_content, part_path, **vars)
                 content_parts.append(part_content)

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -37,6 +37,23 @@ def test_write_file_with_multiple_variables(tmp_path):
 def test_write_file_with_no_variables(tmp_path):
     output_path = tmp_path / "output.txt"
     write_file(output_path, "Hello World")
-    
+
     assert output_path.exists()
-    assert output_path.read_text() == "Hello World" 
+    assert output_path.read_text() == "Hello World"
+
+
+def test_write_file_resolves_nested_includes(tmp_path):
+    templates_dir = tmp_path / "templates"
+    shared_dir = tmp_path / "_shared"
+    templates_dir.mkdir()
+    shared_dir.mkdir()
+
+    (shared_dir / "shared.txt").write_text("Shared", encoding="utf-8")
+    (templates_dir / "first.txt").write_text("First {{INCLUDE:shared.txt}}", encoding="utf-8")
+    main_template = templates_dir / "main.txt"
+    main_template.write_text("Start {{INCLUDE:first.txt}} End", encoding="utf-8")
+
+    output_path = tmp_path / "output.txt"
+    write_file(output_path, main_template)
+
+    assert output_path.read_text(encoding="utf-8") == "Start First Shared End"


### PR DESCRIPTION
## Summary
- Explicitly read and write templates using UTF-8 in fs utilities
- Document UTF-8 behavior in fs helpers and add nested include test

## Testing
- `pytest tests/unit/utils/test_fs.py -k nested -vv`
- `pytest` *(fails: SyntaxError in `src/utils/codegen.py`)*

------
https://chatgpt.com/codex/tasks/task_e_68953453656c83319a5994c6ecb04e4a