### PR TITLE
Add Rust service example and restructure library examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ kickstart create mono my-platform --helm
 
 # Library or CLI tool
 kickstart create lib my-utils --lang python
+kickstart create lib my-utils --lang rust --gh
 kickstart create cli my-tool --lang python
 ```
 

--- a/src/utils/help_generator.py
+++ b/src/utils/help_generator.py
@@ -151,13 +151,17 @@ class KickstartHelpGenerator:
         types = self.get_available_project_types()
         
         examples = []
-        
+
         # Service examples
         if "service" in types:
             if "python" in languages:
                 examples.append("kickstart create service my-api --lang python")
             if "rust" in languages:
-                examples.append("kickstart create lib my-utils --lang rust --gh")
+                examples.append("kickstart create service my-api --lang rust")
+
+        # Library examples
+        if "lib" in types and "rust" in languages:
+            examples.append("kickstart create lib my-utils --lang rust --gh")
         
         # Frontend examples  
         if "frontend" in types:

--- a/tests/unit/utils/test_help_generator.py
+++ b/tests/unit/utils/test_help_generator.py
@@ -1,0 +1,16 @@
+from src.utils.help_generator import KickstartHelpGenerator
+
+
+def test_generate_examples_includes_rust_service_and_lib(monkeypatch):
+    generator = KickstartHelpGenerator()
+
+    monkeypatch.setattr(generator, "get_available_languages", lambda: ["python", "rust"])
+    monkeypatch.setattr(generator, "get_available_project_types", lambda: ["service", "lib"])
+
+    examples = generator.generate_examples()
+
+    assert examples == [
+        "kickstart create service my-api --lang python",
+        "kickstart create service my-api --lang rust",
+        "kickstart create lib my-utils --lang rust --gh",
+    ]


### PR DESCRIPTION
## Summary
- add Rust service example in CLI help generation
- move Rust library example under a dedicated `lib` block
- document Rust library usage and cover with unit test

## Testing
- `PYTHONPATH=. pytest tests/unit/utils/test_help_generator.py`
- `PYTHONPATH=. pytest` *(fails: SyntaxError in src/utils/codegen.py: f-string expression part cannot include a backslash)*

------
https://chatgpt.com/codex/tasks/task_e_6895351d434c8331851fc021a01b78eb