### PR TITLE
Handle missing kickstart asset in updater

### DIFF
--- a/src/utils/updater.py
+++ b/src/utils/updater.py
@@ -3,7 +3,7 @@ import shutil
 import requests
 from pathlib import Path
 from src import __version__
-from .logger import info, success, error
+from .logger import info, success, warn, error
 
 REPO = "woud420/kickstart"
 RELEASE_URL = f"https://api.github.com/repos/{REPO}/releases/latest"
@@ -16,9 +16,14 @@ def check_for_update():
         r.raise_for_status()
         data = r.json()
         latest = data["tag_name"].lstrip("v")
-        download_url = next(asset["browser_download_url"]
-                            for asset in data["assets"]
-                            if asset["name"] == "kickstart")
+        assets = data["assets"]
+        kickstart_asset = next((asset for asset in assets if asset["name"] == "kickstart"), None)
+
+        if kickstart_asset is None:
+            warn("No 'kickstart' asset found; update aborted")
+            return
+
+        download_url = kickstart_asset["browser_download_url"]
 
         if latest == __version__:
             success("You're already up to date")

--- a/tests/unit/utils/test_updater.py
+++ b/tests/unit/utils/test_updater.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch, MagicMock
+
+from src.utils.updater import check_for_update
+
+
+def test_missing_kickstart_asset_logs_warning_and_aborts():
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {
+        "tag_name": "v1.2.3",
+        "assets": [],
+    }
+
+    with patch("requests.get", return_value=mock_response) as mock_get, \
+         patch("src.utils.updater.warn") as mock_warn:
+        assert check_for_update() is None
+        mock_warn.assert_called_once_with("No 'kickstart' asset found; update aborted")
+        mock_get.assert_called_once()


### PR DESCRIPTION
## Summary
- warn and abort when release lacks `kickstart` asset
- add unit test covering missing asset scenario

## Testing
- `pre-commit run --files src/utils/updater.py tests/unit/utils/test_updater.py`
- `PYTHONPATH=. pytest tests/unit/utils/test_updater.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68953a7820b08331bc0624f9c053ceec