### PR TITLE
Remove unused import in test_config

### DIFF
--- a/tests/unit/utils/test_config.py
+++ b/tests/unit/utils/test_config.py
@@ -1,6 +1,5 @@
 import pytest
-from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import patch
 import toml
 from src.utils.config import load_config
 


### PR DESCRIPTION
## Summary
- remove unused `mock_open` import from unit test
- drop leftover `Path` import

## Testing
- `pre-commit run --files tests/unit/utils/test_config.py`
- `python -m pyflakes tests/unit/utils/test_config.py`
- `pytest tests/unit/utils/test_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68953a8830588331a48c916bc8cc8b34