### PR TITLE
Add typed logger protocol and docstrings

### DIFF
--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,6 +1,48 @@
+"""Simple utilities for rich colored console logging."""
+
+from typing import Protocol
+
 from rich import print
 
-def info(msg): print(f"[cyan]➤ {msg}")
-def success(msg): print(f"[green]✔ {msg}")
-def warn(msg): print(f"[yellow]⚠ {msg}")
-def error(msg): print(f"[red]✖ {msg}")
+
+class Logger(Protocol):
+    """Protocol describing a basic logger interface."""
+
+    def info(self, msg: str) -> None:
+        """Log an informational message."""
+        ...
+
+    def success(self, msg: str) -> None:
+        """Log a success message."""
+        ...
+
+    def warn(self, msg: str) -> None:
+        """Log a warning message."""
+        ...
+
+    def error(self, msg: str) -> None:
+        """Log an error message."""
+        ...
+
+
+def info(msg: str) -> None:
+    """Display an informational message."""
+    print(f"[cyan]➤ {msg}")
+
+
+def success(msg: str) -> None:
+    """Display a success message."""
+    print(f"[green]✔ {msg}")
+
+
+def warn(msg: str) -> None:
+    """Display a warning message."""
+    print(f"[yellow]⚠ {msg}")
+
+
+def error(msg: str) -> None:
+    """Display an error message."""
+    print(f"[red]✖ {msg}")
+
+
+__all__ = ["Logger", "info", "success", "warn", "error"]


### PR DESCRIPTION
## Summary
- add `Logger` protocol to define logging interface
- add type hints and docstrings to console logging helpers

## Testing
- `pre-commit run --files src/utils/logger.py`
- `PYTHONPATH=. pytest` *(fails: FileNotFoundError: No such file or directory: '/workspace/kickstart/src/templates/python/README.md.tpl')*

------
https://chatgpt.com/codex/tasks/task_e_68953a8a27ac833184884ef6d252f5be