### PR TITLE
feat(cli): add non-interactive create mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ kickstart create cli my-tool --lang python
 kickstart create  # Guided wizard
 ```
 
+**Non-interactive Mode:**
+```bash
+kickstart create service my-api --lang python --root /tmp --non-interactive  # or --yes
+```
+Provide all required arguments to skip prompts.
+
 **Batch Generation:**
 ```bash
 kickstart --manifest components.md  # Generate multiple projects from manifest

--- a/src/templates/python/README.md.tpl
+++ b/src/templates/python/README.md.tpl
@@ -1,0 +1,16 @@
+# {{SERVICE_NAME}}
+
+A Python project generated with Kickstart.
+
+## Development
+
+```bash
+make install
+make tests
+```
+
+## Project Structure
+
+- `src/` - Source code
+- `tests/` - Test suite
+- `Makefile` - Common commands

--- a/tests/integration/test_create_frontend.py
+++ b/tests/integration/test_create_frontend.py
@@ -12,7 +12,16 @@ def test_create_frontend():
         env["PYTHONPATH"] = str(repo_root)
 
         subprocess.run(
-            [sys.executable, str(repo_root / "kickstart.py"), "create", "frontend", "my-app", "--root", str(tmp)],
+            [
+                sys.executable,
+                str(repo_root / "kickstart.py"),
+                "create",
+                "frontend",
+                "my-app",
+                "--root",
+                str(tmp),
+                "--non-interactive",
+            ],
             cwd=tmp,
             check=True,
             env=env,
@@ -36,7 +45,16 @@ def test_create_frontend_with_root():
         custom_root.mkdir()
 
         subprocess.run(
-            [sys.executable, str(repo_root / "kickstart.py"), "create", "frontend", "my-app", "--root", str(custom_root)],
+            [
+                sys.executable,
+                str(repo_root / "kickstart.py"),
+                "create",
+                "frontend",
+                "my-app",
+                "--root",
+                str(custom_root),
+                "--non-interactive",
+            ],
             cwd=tmp,
             check=True,
             env=env,

--- a/tests/integration/test_create_lib.py
+++ b/tests/integration/test_create_lib.py
@@ -12,7 +12,18 @@ def test_create_python_lib():
         env["PYTHONPATH"] = str(repo_root)
 
         subprocess.run(
-            [sys.executable, str(repo_root / "kickstart.py"), "create", "lib", "my-lib", "--lang", "python", "--root", str(tmp)],
+            [
+                sys.executable,
+                str(repo_root / "kickstart.py"),
+                "create",
+                "lib",
+                "my-lib",
+                "--lang",
+                "python",
+                "--root",
+                str(tmp),
+                "--non-interactive",
+            ],
             cwd=tmp,
             check=True,
             env=env,
@@ -35,7 +46,18 @@ def test_create_python_lib_with_root():
         custom_root.mkdir()
 
         subprocess.run(
-            [sys.executable, str(repo_root / "kickstart.py"), "create", "lib", "my-lib", "--lang", "python", "--root", str(custom_root)],
+            [
+                sys.executable,
+                str(repo_root / "kickstart.py"),
+                "create",
+                "lib",
+                "my-lib",
+                "--lang",
+                "python",
+                "--root",
+                str(custom_root),
+                "--non-interactive",
+            ],
             cwd=tmp,
             check=True,
             env=env,

--- a/tests/integration/test_create_mono.py
+++ b/tests/integration/test_create_mono.py
@@ -12,7 +12,16 @@ def test_create_monorepo_kustomize():
         env["PYTHONPATH"] = str(repo_root)
 
         subprocess.run(
-            [sys.executable, str(repo_root / "kickstart.py"), "create", "mono", "infra-stack", "--root", str(tmp)],
+            [
+                sys.executable,
+                str(repo_root / "kickstart.py"),
+                "create",
+                "mono",
+                "infra-stack",
+                "--root",
+                str(tmp),
+                "--non-interactive",
+            ],
             cwd=tmp,
             check=True,
             env=env,
@@ -34,7 +43,16 @@ def test_create_monorepo_kustomize_with_root():
         custom_root.mkdir()
 
         subprocess.run(
-            [sys.executable, str(repo_root / "kickstart.py"), "create", "mono", "infra-stack", "--root", str(custom_root)],
+            [
+                sys.executable,
+                str(repo_root / "kickstart.py"),
+                "create",
+                "mono",
+                "infra-stack",
+                "--root",
+                str(custom_root),
+                "--non-interactive",
+            ],
             cwd=tmp,
             check=True,
             env=env,

--- a/tests/integration/test_create_service.py
+++ b/tests/integration/test_create_service.py
@@ -12,7 +12,18 @@ def test_create_python_service():
         env["PYTHONPATH"] = str(repo_root)
 
         subprocess.run(
-            [sys.executable, str(repo_root / "kickstart.py"), "create", "service", "hello-api", "--lang", "python", "--root", str(tmp)],
+            [
+                sys.executable,
+                str(repo_root / "kickstart.py"),
+                "create",
+                "service",
+                "hello-api",
+                "--lang",
+                "python",
+                "--root",
+                str(tmp),
+                "--non-interactive",
+            ],
             cwd=tmp,
             check=True,
             env=env,
@@ -35,7 +46,18 @@ def test_create_python_service_with_root():
         custom_root.mkdir()
 
         subprocess.run(
-            [sys.executable, str(repo_root / "kickstart.py"), "create", "service", "hello-api", "--lang", "python", "--root", str(custom_root)],
+            [
+                sys.executable,
+                str(repo_root / "kickstart.py"),
+                "create",
+                "service",
+                "hello-api",
+                "--lang",
+                "python",
+                "--root",
+                str(custom_root),
+                "--non-interactive",
+            ],
             cwd=tmp,
             check=True,
             env=env,

--- a/tests/unit/cli/test_non_interactive_create.py
+++ b/tests/unit/cli/test_non_interactive_create.py
@@ -1,0 +1,35 @@
+from typer.testing import CliRunner
+
+from src.cli.main import app
+import src.cli.main as cli_main
+
+
+def test_non_interactive_create_requires_args(tmp_path, monkeypatch):
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["create", "service", "--non-interactive"])
+
+    assert result.exit_code != 0
+    assert "non-interactive mode requires" in result.stdout.lower()
+
+
+def test_non_interactive_create_service(tmp_path, monkeypatch):
+    runner = CliRunner()
+    recorded = {}
+
+    def fake_create_service(name, lang, gh, config, helm=False, root=None):
+        recorded["name"] = name
+        recorded["root"] = root
+
+    monkeypatch.setattr(cli_main, "create_service", fake_create_service)
+    monkeypatch.setattr(cli_main, "load_config", lambda: {})
+
+    result = runner.invoke(
+        app,
+        ["create", "service", "my-svc", "--root", str(tmp_path), "--non-interactive"],
+    )
+
+    assert result.exit_code == 0
+    assert recorded["name"] == "my-svc"
+    assert recorded["root"] == str(tmp_path)
+

--- a/tests/unit/generators/test_repo_hooks.py
+++ b/tests/unit/generators/test_repo_hooks.py
@@ -8,28 +8,28 @@ from src.generators.lib import LibraryGenerator, CLIGenerator
 from src.generators.monorepo import MonorepoGenerator
 
 
-@patch('src.generators.service.create_repo')
+@patch('src.generators.mixins.create_repo')
 def test_service_generator_calls_create_repo(mock_repo, tmp_path):
     gen = ServiceGenerator('svc', 'python', True, {}, root=tmp_path)
     gen.create()
     mock_repo.assert_called_once_with('svc')
 
 
-@patch('src.generators.frontend.create_repo')
+@patch('src.generators.mixins.create_repo')
 def test_frontend_generator_calls_create_repo(mock_repo, tmp_path):
     gen = FrontendGenerator('ui', True, {}, root=tmp_path)
     gen.create()
     mock_repo.assert_called_once_with('ui')
 
 
-@patch('src.generators.lib.create_repo')
+@patch('src.generators.mixins.create_repo')
 def test_lib_generator_calls_create_repo(mock_repo, tmp_path):
     gen = LibraryGenerator('lib', 'python', True, {}, root=tmp_path)
     gen.create()
     mock_repo.assert_called_once_with('lib')
 
 
-@patch('src.generators.lib.create_repo')
+@patch('src.generators.mixins.create_repo')
 def test_cli_generator_calls_create_repo(mock_repo, tmp_path):
     gen = CLIGenerator('cli', 'python', True, {}, root=tmp_path)
     gen.create()


### PR DESCRIPTION
## Summary
- add `--non-interactive/--yes` flag to `kickstart create`
- document non-interactive usage
- expand tests for non-interactive mode and update integration cases

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_68953bbceb648331b290b19dc9f7a706