### PR TITLE
[codex] Validate service extension capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ poetry run kickstart create mono product-stack
 - Preferred stack: Rust, TypeScript, Python, SQL, and C++.
 - Go is supported as a tolerated service target; Python and Rust are the first-class library/CLI targets.
 - Service execution models: containers by default, Cloudflare Workers when requested.
+- Implemented service extensions currently target Python/FastAPI container services: Postgres, Redis, and JWT.
 - System provider targets: `multi`, `aws`, `gcp`, `cloudflare`, or `none`.
 - System platform profiles: `kubernetes`, `cloudflare-workers`, or `hybrid`.
 - Dockerfiles are image artifacts; Helm and Kustomize are Kubernetes artifact styles; Wrangler is the Cloudflare Worker artifact path.

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -18,6 +18,7 @@ Resolved metadata in `.kickstart/scaffold.json`:
 - runtime platforms
 - emitted artifacts
 - provider targets
+- selected capabilities, such as implemented service extensions
 - knowledge adapter
 
 Outputs:
@@ -46,6 +47,8 @@ Do not infer unsupported options. Use existing registries and typed plans.
 - Language setup plans: `src/generator/language_setup.py`
 - Stack registry: `src/stack/`
 - Templates: `src/templates/`
+
+Implemented service extensions are intentionally narrow. As of this contract, `postgres`, `redis`, and `jwt` are supported for Python/FastAPI container services only. Do not pass unsupported extension options and assume they were generated.
 
 ## Defaults
 

--- a/docs/human-guide.md
+++ b/docs/human-guide.md
@@ -27,11 +27,13 @@ Execution model:
 - `container`: default service runtime
 - `cloudflare-workers`: TypeScript or Rust Worker scaffold
 
-Python extensions:
+Implemented service extensions:
 
 - `--database postgres`
 - `--cache redis`
 - `--auth jwt`
+
+These currently apply to Python/FastAPI container services only. Other language/runtime/framework combinations fail loudly until their templates are implemented.
 
 ## Library And CLI Options
 

--- a/docs/scaffold-contract.md
+++ b/docs/scaffold-contract.md
@@ -23,7 +23,10 @@ There is no separate root architecture document. `docs/architecture/` is the can
 - `execution.platforms`: where runtime artifacts are meant to run, for example `local`, `kubernetes`, `cloudflare-workers`, `cloudflare-containers`, `static-host`, or `none`.
 - `artifacts`: emitted files and tool configs, for example `image: dockerfile`, `kubernetes: kustomize`, `kubernetes: helm`, `worker: wrangler`, `iac: terraform`, or `ci: github-actions`.
 - `provider.targets`: infrastructure providers targeted by generated IaC or platform config, for example `aws`, `gcp`, or `cloudflare`.
+- `capabilities`: optional generated capabilities with real code support, for example `service_extensions: { database: postgres, cache: redis, auth: jwt }`.
 - `knowledge_adapter`: external knowledge integration metadata, for example `none`, `obsidian`, `backstage`, or `both`.
+
+Implemented service extensions currently apply only to Python/FastAPI container services. Unsupported combinations fail instead of generating a partial or silent scaffold.
 
 Systems contain other project kinds and are currently generated through the `mono` command with `project.repo_layout: monorepo`.
 

--- a/src/cli/dispatch.py
+++ b/src/cli/dispatch.py
@@ -110,4 +110,4 @@ def dispatch_project_creation(options: CreateOptions, config: GeneratorConfig, c
         creators.monorepo(options.name, options.gh, config, **monorepo_kwargs)
         return
 
-    print(f"[bold red]❌ Type '{options.project_type}' not supported.[/]")
+    print(f"[bold red]Type '{options.project_type}' not supported.[/]")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -18,6 +18,7 @@ from src.api import (
 from src.cli.dispatch import ProjectCreators, dispatch_project_creation
 from src.cli.options import CreateCommandOptions, CreateOptions, ResolvedCreateArgs
 from src.cli.prompts import ConfirmReader, PromptReader, prompt_for_missing_args
+from src.utils.error_handling import KickstartError
 from src.utils.config import load_config
 from src.utils.types import GeneratorConfig
 from src.utils.updater import check_for_update
@@ -141,9 +142,21 @@ def create(
     lang: str = typer.Option("python", "--lang", "-l"),
     gh: bool = typer.Option(False, "--gh", help="Create GitHub repo"),
     helm: bool = typer.Option(False, "--helm", help="Add Helm scaffolding (services or mono only)"),
-    database: Optional[str] = typer.Option(None, "--database", help="Database extension (postgres, mysql, sqlite)"),
-    cache: Optional[str] = typer.Option(None, "--cache", help="Cache extension (redis, memcached)"),
-    auth: Optional[str] = typer.Option(None, "--auth", help="Authentication extension (jwt, oauth)"),
+    database: Optional[str] = typer.Option(
+        None,
+        "--database",
+        help="Database extension (implemented: postgres for Python/FastAPI services)",
+    ),
+    cache: Optional[str] = typer.Option(
+        None,
+        "--cache",
+        help="Cache extension (implemented: redis for Python/FastAPI services)",
+    ),
+    auth: Optional[str] = typer.Option(
+        None,
+        "--auth",
+        help="Authentication extension (implemented: jwt for Python/FastAPI services)",
+    ),
     framework: Optional[str] = typer.Option(
         None,
         "--framework",
@@ -184,8 +197,11 @@ def create(
 
     except KeyboardInterrupt:
         print("\n[yellow]Operation cancelled by user.[/]")
+    except KickstartError as exc:
+        print(f"[bold red]Failed to create project: {exc}[/]")
+        raise typer.Exit(code=1) from exc
     except Exception as exc:
-        print(f"[bold red]❌ Failed to create project: {exc}[/]")
+        print(f"[bold red]Failed to create project: {exc}[/]")
         logger.exception("Project creation failed")
         raise typer.Exit(code=1) from exc
 

--- a/src/cli/prompts.py
+++ b/src/cli/prompts.py
@@ -71,17 +71,17 @@ def prompt_for_missing_args(
 
     if project_type == "service" and lang == "python" and interactive_mode:
         if database is None:
-            database = prompt.ask("Database extension", choices=["none", "postgres", "mysql", "sqlite"], default="none")
+            database = prompt.ask("Database extension", choices=["none", "postgres"], default="none")
             if database == "none":
                 database = None
 
         if cache is None:
-            cache = prompt.ask("Cache extension", choices=["none", "redis", "memcached"], default="none")
+            cache = prompt.ask("Cache extension", choices=["none", "redis"], default="none")
             if cache == "none":
                 cache = None
 
         if auth is None:
-            auth = prompt.ask("Authentication extension", choices=["none", "jwt", "oauth"], default="none")
+            auth = prompt.ask("Authentication extension", choices=["none", "jwt"], default="none")
             if auth == "none":
                 auth = None
 

--- a/src/generator/scaffold_contract.py
+++ b/src/generator/scaffold_contract.py
@@ -35,6 +35,16 @@ class ScaffoldProviderManifest(TypedDict):
     targets: list[str]
 
 
+class ScaffoldServiceExtensionsManifest(TypedDict, total=False):
+    database: str
+    cache: str
+    auth: str
+
+
+class ScaffoldCapabilitiesManifest(TypedDict, total=False):
+    service_extensions: ScaffoldServiceExtensionsManifest
+
+
 class ScaffoldLifecycleManifest(TypedDict, total=False):
     install: str
     test: str
@@ -66,6 +76,7 @@ class ScaffoldOptionSemanticsManifest(TypedDict):
     runtime_platforms: str
     artifacts: str
     provider_targets: str
+    capabilities: str
     lifecycle: str
     composition: str
     knowledge_adapter: str
@@ -78,6 +89,7 @@ class ScaffoldManifest(TypedDict):
     execution: ScaffoldExecutionManifest
     artifacts: ScaffoldArtifactsManifest
     provider: ScaffoldProviderManifest
+    capabilities: ScaffoldCapabilitiesManifest
     lifecycle: ScaffoldLifecycleManifest
     knowledge_adapter: str
     docs: ScaffoldDocsManifest
@@ -153,6 +165,26 @@ class ScaffoldLifecycle:
 
 
 @dataclass(frozen=True)
+class ScaffoldServiceExtensions:
+    """Service extensions selected for a generated scaffold."""
+
+    database: str | None = None
+    cache: str | None = None
+    auth: str | None = None
+
+    def manifest(self) -> ScaffoldServiceExtensionsManifest:
+        """Return JSON-ready extension fields without empty values."""
+        manifest: ScaffoldServiceExtensionsManifest = {}
+        if self.database is not None:
+            manifest["database"] = self.database
+        if self.cache is not None:
+            manifest["cache"] = self.cache
+        if self.auth is not None:
+            manifest["auth"] = self.auth
+        return manifest
+
+
+@dataclass(frozen=True)
 class ScaffoldContract:
     """Explicit contract for generated project shape and option vocabulary."""
 
@@ -161,6 +193,7 @@ class ScaffoldContract:
     runtime_platforms: tuple[str, ...]
     artifacts: ScaffoldArtifacts = field(default_factory=ScaffoldArtifacts)
     lifecycle: ScaffoldLifecycle | None = None
+    service_extensions: ScaffoldServiceExtensions = field(default_factory=ScaffoldServiceExtensions)
     provider_targets: tuple[str, ...] = ()
     knowledge_adapter: str = "none"
     repo_layout: RepoLayout = "single-project"
@@ -182,6 +215,7 @@ class ScaffoldContract:
             },
             "artifacts": self.artifacts.manifest(),
             "provider": {"targets": list(self.provider_targets)},
+            "capabilities": self._capabilities_manifest(),
             "lifecycle": self._lifecycle().manifest(),
             "knowledge_adapter": self.knowledge_adapter,
             "docs": {
@@ -198,6 +232,7 @@ class ScaffoldContract:
                 "runtime_platforms": "where generated runtime artifacts are meant to run",
                 "artifacts": "files and tool configs emitted by the scaffold",
                 "provider_targets": "infrastructure providers targeted by generated IaC or platform config",
+                "capabilities": "selected optional capabilities that have generated code and validation support",
                 "lifecycle": "project-local commands that agents and humans can run to install, test, and check the scaffold",
                 "composition": "system-only metadata for discovering contained project manifests",
                 "knowledge_adapter": "external knowledge integration metadata",
@@ -223,6 +258,13 @@ class ScaffoldContract:
             )
             return system_manifest
         return manifest
+
+    def _capabilities_manifest(self) -> ScaffoldCapabilitiesManifest:
+        """Return generated optional capability metadata."""
+        service_extensions = self.service_extensions.manifest()
+        if service_extensions:
+            return {"service_extensions": service_extensions}
+        return {}
 
     def manifest_json(self, project_name: str) -> str:
         """Return stable, pretty JSON for `.kickstart/scaffold.json`."""

--- a/src/generator/service.py
+++ b/src/generator/service.py
@@ -17,7 +17,8 @@ from src.utils.extension_manager import ExtensionManager
 from src.stack.profile import stack_registry
 from src.stack.types import TemplateConfig
 from src.generator.layouts import python_package_directories, service_directories, worker_directories
-from src.generator.scaffold_contract import ScaffoldArtifacts, ScaffoldContract
+from src.generator.scaffold_contract import ScaffoldArtifacts, ScaffoldContract, ScaffoldServiceExtensions
+from src.generator.service_capabilities import ServiceExtensionSelection, validate_service_extensions
 from src.generator.specs import ServiceSpec
 from src.generator.template_plan import TemplatePlan
 from src.utils.types import GeneratorConfig
@@ -135,6 +136,7 @@ class ServiceGenerator(BaseGenerator):
         Raises:
             LanguageNotSupportedError: If unsupported language is specified
         """
+        extension_selection = self._validate_extension_selection()
         profile = stack_registry.service_selection(self.lang, self.runtime, helm=self.helm)
 
         if profile.runtime == "cloudflare-workers":
@@ -168,6 +170,7 @@ class ServiceGenerator(BaseGenerator):
                     image="dockerfile",
                     kubernetes="helm" if self.helm else None,
                 ),
+                service_extensions=self._scaffold_service_extensions(extension_selection),
             ),
             success_message=success_message,
             language_setup_fn=self._setup_service_specific,
@@ -177,6 +180,28 @@ class ServiceGenerator(BaseGenerator):
 
         if not success:
             warn(f"Failed to create {self.lang} service '{self.name}'")
+
+    def _validate_extension_selection(self) -> ServiceExtensionSelection:
+        """Validate database, cache, and auth extensions for this service."""
+        return validate_service_extensions(
+            language=self.lang,
+            runtime=self.runtime,
+            framework=self.framework,
+            database=self.database,
+            cache=self.cache,
+            auth=self.auth,
+        )
+
+    def _scaffold_service_extensions(
+        self,
+        selection: ServiceExtensionSelection,
+    ) -> ScaffoldServiceExtensions:
+        """Convert validated extension selections to manifest metadata."""
+        return ScaffoldServiceExtensions(
+            database=selection.database,
+            cache=selection.cache,
+            auth=selection.auth,
+        )
 
     def _create_cloudflare_worker_project(self) -> None:
         """Create a Cloudflare Worker service project."""

--- a/src/generator/service_capabilities.py
+++ b/src/generator/service_capabilities.py
@@ -1,0 +1,139 @@
+"""Service capability validation for language/runtime extension options."""
+
+from dataclasses import dataclass
+
+from src.utils.error_handling import ExtensionError
+
+
+@dataclass(frozen=True)
+class ServiceExtensionSelection:
+    """Selected service extensions after validation."""
+
+    database: str | None = None
+    cache: str | None = None
+    auth: str | None = None
+
+    def has_extensions(self) -> bool:
+        """Return whether any extension option was selected."""
+        return self.database is not None or self.cache is not None or self.auth is not None
+
+
+@dataclass(frozen=True)
+class ServiceExtensionSupport:
+    """Implemented extensions for a language/runtime/framework combination."""
+
+    databases: tuple[str, ...] = ()
+    caches: tuple[str, ...] = ()
+    auth: tuple[str, ...] = ()
+
+
+IMPLEMENTED_DATABASE_EXTENSIONS = ("postgres",)
+IMPLEMENTED_CACHE_EXTENSIONS = ("redis",)
+IMPLEMENTED_AUTH_EXTENSIONS = ("jwt",)
+
+_SERVICE_EXTENSION_SUPPORT: dict[tuple[str, str, str], ServiceExtensionSupport] = {
+    ("python", "container", "fastapi"): ServiceExtensionSupport(
+        databases=IMPLEMENTED_DATABASE_EXTENSIONS,
+        caches=IMPLEMENTED_CACHE_EXTENSIONS,
+        auth=IMPLEMENTED_AUTH_EXTENSIONS,
+    )
+}
+
+
+def normalize_framework(framework: str | None) -> str:
+    """Return the canonical framework capability id."""
+    if framework is None or framework == "fastapi":
+        return "fastapi"
+    return framework
+
+
+def validate_service_extensions(
+    *,
+    language: str,
+    runtime: str,
+    framework: str | None,
+    database: str | None,
+    cache: str | None,
+    auth: str | None,
+) -> ServiceExtensionSelection:
+    """Validate selected service extensions for a language/runtime/framework."""
+    selection = ServiceExtensionSelection(
+        database=_normalize_optional(database),
+        cache=_normalize_optional(cache),
+        auth=_normalize_optional(auth),
+    )
+    framework_id = normalize_framework(framework)
+    support = _SERVICE_EXTENSION_SUPPORT.get((language, runtime, framework_id), ServiceExtensionSupport())
+
+    _validate_category(
+        category="database",
+        selected=selection.database,
+        supported=support.databases,
+        implemented=IMPLEMENTED_DATABASE_EXTENSIONS,
+        language=language,
+        runtime=runtime,
+        framework=framework_id,
+    )
+    _validate_category(
+        category="cache",
+        selected=selection.cache,
+        supported=support.caches,
+        implemented=IMPLEMENTED_CACHE_EXTENSIONS,
+        language=language,
+        runtime=runtime,
+        framework=framework_id,
+    )
+    _validate_category(
+        category="auth",
+        selected=selection.auth,
+        supported=support.auth,
+        implemented=IMPLEMENTED_AUTH_EXTENSIONS,
+        language=language,
+        runtime=runtime,
+        framework=framework_id,
+    )
+    return selection
+
+
+def _normalize_optional(value: str | None) -> str | None:
+    """Normalize absent option spellings."""
+    if value is None or value == "none":
+        return None
+    return value
+
+
+def _validate_category(
+    *,
+    category: str,
+    selected: str | None,
+    supported: tuple[str, ...],
+    implemented: tuple[str, ...],
+    language: str,
+    runtime: str,
+    framework: str,
+) -> None:
+    """Validate one extension category."""
+    if selected is None:
+        return
+
+    if selected not in implemented:
+        raise ExtensionError(
+            "{category} extension '{selected}' is not implemented. Implemented {category} extensions: {implemented}.".format(
+                category=category,
+                selected=selected,
+                implemented=", ".join(implemented) or "none",
+            )
+        )
+
+    if selected not in supported:
+        raise ExtensionError(
+            "{category} extension '{selected}' is not supported for {language}/{runtime}/{framework} services. "
+            "Currently supported for this combination: {supported}.".format(
+                category=category,
+                selected=selected,
+                language=language,
+                runtime=runtime,
+                framework=framework,
+                supported=", ".join(supported) or "none",
+            )
+        )

--- a/src/generator/service_capabilities.py
+++ b/src/generator/service_capabilities.py
@@ -40,8 +40,10 @@ _SERVICE_EXTENSION_SUPPORT: dict[tuple[str, str, str], ServiceExtensionSupport] 
 }
 
 
-def normalize_framework(framework: str | None) -> str:
-    """Return the canonical framework capability id."""
+def normalize_framework(*, language: str, framework: str | None) -> str:
+    """Return the canonical framework capability id for validation messages."""
+    if language != "python":
+        return framework or "default"
     if framework is None or framework == "fastapi":
         return "fastapi"
     return framework
@@ -62,7 +64,7 @@ def validate_service_extensions(
         cache=_normalize_optional(cache),
         auth=_normalize_optional(auth),
     )
-    framework_id = normalize_framework(framework)
+    framework_id = normalize_framework(language=language, framework=framework)
     support = _SERVICE_EXTENSION_SUPPORT.get((language, runtime, framework_id), ServiceExtensionSupport())
 
     _validate_category(

--- a/src/templates/python/extensions/minimal/core/main.py.tpl
+++ b/src/templates/python/extensions/minimal/core/main.py.tpl
@@ -1,10 +1,7 @@
 """Main application entry point.
 
-This is a minimal HTTP server using only Python standard library.
-For enhanced functionality, use progressive enhancement flags:
-- --database postgres (adds database support)
-- --cache redis (adds caching support)  
-- --auth jwt (adds authentication support)
+This is a minimal HTTP server using only the Python standard library.
+Use the default FastAPI scaffold for currently implemented service extensions.
 """
 
 import json

--- a/src/templates/python/extensions/minimal/core/requirements.txt.tpl
+++ b/src/templates/python/extensions/minimal/core/requirements.txt.tpl
@@ -2,10 +2,7 @@
 # This creates a minimal HTTP server using only standard library
 
 # Standard library only - no external dependencies
-# For enhanced functionality, use extensions like:
-# --database postgres (adds asyncpg, psycopg2)
-# --cache redis (adds redis)
-# --auth jwt (adds python-jose, passlib)
+# Use the default FastAPI scaffold for currently implemented service extensions.
 
 # Development and testing (minimal set)
 pytest>=8.4,<9

--- a/tests/integration/test_project_creation.py
+++ b/tests/integration/test_project_creation.py
@@ -118,6 +118,37 @@ class TestServiceCreation:
         }
         assert manifest["execution"] == {"models": ["container"], "platforms": ["local"]}
         assert manifest["artifacts"] == {"image": "dockerfile"}
+        assert manifest["capabilities"] == {}
+
+    def test_python_service_extension_manifest(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
+        """Test Python service extensions are recorded in the scaffold manifest."""
+        service_name = "test-python-service-extensions"
+
+        generator = ServiceGenerator(
+            name=service_name,
+            lang="python",
+            gh=False,
+            config=mock_config,
+            root=str(temp_project_dir),
+            database="postgres",
+            cache="redis",
+            auth="jwt",
+        )
+        generator.create()
+
+        project_path = temp_project_dir / service_name
+        manifest = json.loads((project_path / ".kickstart/scaffold.json").read_text())
+
+        assert manifest["capabilities"] == {
+            "service_extensions": {
+                "auth": "jwt",
+                "cache": "redis",
+                "database": "postgres",
+            }
+        }
+        assert (project_path / "src/clients/database.py").exists()
+        assert (project_path / "src/clients/cache.py").exists()
+        assert (project_path / "src/handler/auth.py").exists()
     
     def test_rust_service_creation_with_helm(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
         """Test Rust service creation with Helm charts."""

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import patch
 from typer.testing import CliRunner
 from src.cli.main import app
+from src.utils.error_handling import ExtensionError
 
 
 @pytest.fixture
@@ -463,6 +464,20 @@ def test_create_service_exception_propagation(mock_load_config, mock_create_serv
     # Typer should catch the exception and exit with non-zero code
     assert result.exit_code != 0
     assert "Test error" in result.stdout
+
+
+@patch('src.cli.main.create_service')
+@patch('src.cli.main.load_config')
+def test_create_service_validation_error_is_concise(mock_load_config, mock_create_service, runner):
+    """Test expected validation errors do not print tracebacks."""
+    mock_load_config.return_value = {}
+    mock_create_service.side_effect = ExtensionError("cache extension 'redis' is not supported")
+
+    result = runner.invoke(app, ["create", "service", "test", "--root", "/tmp", "--cache", "redis"])
+
+    assert result.exit_code != 0
+    assert "cache extension 'redis' is not supported" in result.stdout
+    assert "Traceback" not in result.stdout
 
 
 def test_completion_command_invalid_shell(runner):

--- a/tests/unit/generator/test_base.py
+++ b/tests/unit/generator/test_base.py
@@ -76,6 +76,7 @@ def test_create_scaffold_contract_docs(base_generator, tmp_path):
         assert manifest["execution"] == {"models": ["container"], "platforms": ["local"]}
         assert manifest["artifacts"] == {"image": "dockerfile"}
         assert manifest["provider"] == {"targets": []}
+        assert manifest["capabilities"] == {}
 
 @patch('src.generator.base.write_file')
 def test_write_template(mock_write_file, base_generator, tmp_path):

--- a/tests/unit/generator/test_service.py
+++ b/tests/unit/generator/test_service.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest.mock import patch, call
 from src.generator.service import ServiceGenerator
 from src.generator.scaffold_contract import ScaffoldArtifacts
-from src.utils.error_handling import LanguageNotSupportedError
+from src.utils.error_handling import ExtensionError, LanguageNotSupportedError
 
 
 @pytest.fixture
@@ -108,6 +108,51 @@ def test_create_success_python_with_helm_and_gh(
     mock_create_helm_chart.assert_called_once()
     mock_log_success.assert_called_once_with("Python service 'test-service' created successfully in 'test-service'!")
     mock_create_repo.assert_called_once_with("test-service")
+
+
+@patch.object(ServiceGenerator, 'execute_create_flow')
+def test_create_passes_service_extension_capabilities_to_manifest(mock_execute_create_flow):
+    generator = ServiceGenerator(
+        "test-service",
+        "python",
+        False,
+        {},
+        database="postgres",
+        cache="redis",
+        auth="jwt",
+    )
+    mock_execute_create_flow.return_value = True
+
+    generator.create()
+
+    contract = mock_execute_create_flow.call_args.kwargs["scaffold_contract"]
+    assert contract.service_extensions.database == "postgres"
+    assert contract.service_extensions.cache == "redis"
+    assert contract.service_extensions.auth == "jwt"
+
+
+@pytest.mark.parametrize("language", ["rust", "typescript"])
+def test_create_rejects_unsupported_service_extension_language(language):
+    generator = ServiceGenerator("test-service", language, False, {}, cache="redis")
+
+    with pytest.raises(ExtensionError, match="cache extension 'redis' is not supported"):
+        generator.create()
+
+
+@pytest.mark.parametrize(
+    ("option", "value", "kwargs"),
+    [
+        ("database", "mysql", {"database": "mysql"}),
+        ("database", "sqlite", {"database": "sqlite"}),
+        ("cache", "memcached", {"cache": "memcached"}),
+        ("auth", "oauth", {"auth": "oauth"}),
+    ],
+)
+def test_create_rejects_unimplemented_service_extension_values(option, value, kwargs):
+    generator = ServiceGenerator("test-service", "python", False, {}, **kwargs)
+
+    with pytest.raises(ExtensionError, match=f"{option} extension '{value}' is not implemented"):
+        generator.create()
 
 
 @patch.object(ServiceGenerator, 'create_project')

--- a/tests/unit/generator/test_service_capabilities.py
+++ b/tests/unit/generator/test_service_capabilities.py
@@ -23,7 +23,7 @@ def test_python_fastapi_container_accepts_implemented_extensions() -> None:
 
 @pytest.mark.parametrize("language", ["rust", "typescript"])
 def test_non_python_services_reject_current_python_only_extensions(language: str) -> None:
-    with pytest.raises(ExtensionError, match="cache extension 'redis' is not supported"):
+    with pytest.raises(ExtensionError, match=rf"{language}/container/default"):
         validate_service_extensions(
             language=language,
             runtime="container",

--- a/tests/unit/generator/test_service_capabilities.py
+++ b/tests/unit/generator/test_service_capabilities.py
@@ -1,0 +1,77 @@
+"""Tests for service extension capability validation."""
+
+import pytest
+
+from src.generator.service_capabilities import validate_service_extensions
+from src.utils.error_handling import ExtensionError
+
+
+def test_python_fastapi_container_accepts_implemented_extensions() -> None:
+    selection = validate_service_extensions(
+        language="python",
+        runtime="container",
+        framework=None,
+        database="postgres",
+        cache="redis",
+        auth="jwt",
+    )
+
+    assert selection.database == "postgres"
+    assert selection.cache == "redis"
+    assert selection.auth == "jwt"
+
+
+@pytest.mark.parametrize("language", ["rust", "typescript"])
+def test_non_python_services_reject_current_python_only_extensions(language: str) -> None:
+    with pytest.raises(ExtensionError, match="cache extension 'redis' is not supported"):
+        validate_service_extensions(
+            language=language,
+            runtime="container",
+            framework=None,
+            database=None,
+            cache="redis",
+            auth=None,
+        )
+
+
+def test_cloudflare_worker_services_reject_extensions() -> None:
+    with pytest.raises(ExtensionError, match="auth extension 'jwt' is not supported"):
+        validate_service_extensions(
+            language="typescript",
+            runtime="cloudflare-workers",
+            framework=None,
+            database=None,
+            cache=None,
+            auth="jwt",
+        )
+
+
+def test_python_minimal_services_reject_extensions() -> None:
+    with pytest.raises(ExtensionError, match="database extension 'postgres' is not supported"):
+        validate_service_extensions(
+            language="python",
+            runtime="container",
+            framework="minimal",
+            database="postgres",
+            cache=None,
+            auth=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("category", "value", "kwargs"),
+    [
+        ("database", "mysql", {"database": "mysql", "cache": None, "auth": None}),
+        ("database", "sqlite", {"database": "sqlite", "cache": None, "auth": None}),
+        ("cache", "memcached", {"database": None, "cache": "memcached", "auth": None}),
+        ("auth", "oauth", {"database": None, "cache": None, "auth": "oauth"}),
+    ],
+)
+def test_unimplemented_extension_values_reject(category: str, value: str, kwargs: dict[str, str | None]) -> None:
+    with pytest.raises(ExtensionError, match=f"{category} extension '{value}' is not implemented"):
+        validate_service_extensions(
+            language="python",
+            runtime="container",
+            framework=None,
+            **kwargs,
+        )


### PR DESCRIPTION
Closes #34.

## What Changed

- Added a typed service extension capability matrix.
- Kept the currently implemented extension set explicit: Python/FastAPI container services support `postgres`, `redis`, and `jwt`.
- Made unsupported combinations fail loudly instead of silently ignoring flags, including Rust/TypeScript extension requests and unimplemented values such as `mysql`, `sqlite`, `memcached`, and `oauth`.
- Recorded selected service extensions in `.kickstart/scaffold.json` under `capabilities.service_extensions`.
- Updated CLI help, interactive prompts, docs, and the minimal Python template so they do not claim unsupported extension behavior.
- Removed the emoji from CLI error messages and kept expected validation failures concise.
- Clarified validation context labels so Rust/TypeScript errors do not refer to FastAPI.

## Evidence

- `make check` passed: Ruff passed, mypy passed on 36 source files, and `235 passed in 2.11s`.
- Generated Python service with `--database postgres --cache redis --auth jwt` passed generated `make check`.
- Generated manifest for that service includes `capabilities.service_extensions` with `database: postgres`, `cache: redis`, and `auth: jwt`.
- Rust service with `--cache redis` now fails clearly instead of silently ignoring the flag: `rust/container/default`.
- TypeScript service with `--auth jwt` now fails clearly instead of silently ignoring the flag.
- Python service with `--database mysql` now fails clearly because MySQL is not implemented yet.