### PR TITLE
[codex] Add Redis cache support for Rust services

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ poetry run kickstart create mono product-stack
 - Preferred stack: Rust, TypeScript, Python, SQL, and C++.
 - Go is supported as a tolerated service target; Python and Rust are the first-class library/CLI targets.
 - Service execution models: containers by default, Cloudflare Workers when requested.
-- Implemented service extensions currently target Python/FastAPI container services: Postgres, Redis, and JWT.
+- Implemented service extensions are intentionally narrow: Python/FastAPI container services support Postgres, Redis, and JWT; Rust container services support Redis.
 - System provider targets: `multi`, `aws`, `gcp`, `cloudflare`, or `none`.
 - System platform profiles: `kubernetes`, `cloudflare-workers`, or `hybrid`.
 - Dockerfiles are image artifacts; Helm and Kustomize are Kubernetes artifact styles; Wrangler is the Cloudflare Worker artifact path.
@@ -53,7 +53,7 @@ poetry run kickstart create mono product-stack
 
 ```bash
 poetry run kickstart create service my-api --lang python --database postgres --cache redis --auth jwt
-poetry run kickstart create service api-rs --lang rust
+poetry run kickstart create service api-rs --lang rust --cache redis
 poetry run kickstart create service edge-rs --lang rust --runtime cloudflare-workers
 poetry run kickstart create frontend web
 poetry run kickstart create lib core-lib --lang python

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -48,7 +48,12 @@ Do not infer unsupported options. Use existing registries and typed plans.
 - Stack registry: `src/stack/`
 - Templates: `src/templates/`
 
-Implemented service extensions are intentionally narrow. As of this contract, `postgres`, `redis`, and `jwt` are supported for Python/FastAPI container services only. Do not pass unsupported extension options and assume they were generated.
+Implemented service extensions are intentionally narrow. As of this contract:
+
+- Python/FastAPI container services support `postgres`, `redis`, and `jwt`.
+- Rust container services support `redis`.
+
+Do not pass unsupported extension options and assume they were generated.
 
 ## Defaults
 

--- a/docs/human-guide.md
+++ b/docs/human-guide.md
@@ -33,7 +33,12 @@ Implemented service extensions:
 - `--cache redis`
 - `--auth jwt`
 
-These currently apply to Python/FastAPI container services only. Other language/runtime/framework combinations fail loudly until their templates are implemented.
+Support is intentionally narrow:
+
+- Python/FastAPI container services support Postgres, Redis, and JWT.
+- Rust container services support Redis.
+
+Other language/runtime/framework combinations fail loudly until their templates are implemented.
 
 ## Library And CLI Options
 

--- a/docs/scaffold-contract.md
+++ b/docs/scaffold-contract.md
@@ -26,7 +26,7 @@ There is no separate root architecture document. `docs/architecture/` is the can
 - `capabilities`: optional generated capabilities with real code support, for example `service_extensions: { database: postgres, cache: redis, auth: jwt }`.
 - `knowledge_adapter`: external knowledge integration metadata, for example `none`, `obsidian`, `backstage`, or `both`.
 
-Implemented service extensions currently apply only to Python/FastAPI container services. Unsupported combinations fail instead of generating a partial or silent scaffold.
+Implemented service extensions are intentionally narrow. Python/FastAPI container services support Postgres, Redis, and JWT. Rust container services support Redis. Unsupported combinations fail instead of generating a partial or silent scaffold.
 
 Systems contain other project kinds and are currently generated through the `mono` command with `project.repo_layout: monorepo`.
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -150,7 +150,7 @@ def create(
     cache: Optional[str] = typer.Option(
         None,
         "--cache",
-        help="Cache extension (implemented: redis for Python/FastAPI services)",
+        help="Cache extension (implemented: redis for Python/FastAPI and Rust container services)",
     ),
     auth: Optional[str] = typer.Option(
         None,

--- a/src/generator/language_setup.py
+++ b/src/generator/language_setup.py
@@ -14,20 +14,27 @@ class ContentFile:
 
 
 RUST_MODULE_CONTENT = "// Module definitions\n"
+RUST_CLIENTS_MODULE_CONTENT = "pub mod cache;\n"
 
-RUST_MAIN_CONTENT = """use actix_web::{web, App, HttpResponse, HttpServer};
+RUST_MAIN_CONTENT = """use actix_web::{App, HttpResponse, HttpServer, web};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
-        App::new()
-            .route("/", web::get().to(|| async { HttpResponse::Ok().json("Hello World") }))
+        App::new().route(
+            "/",
+            web::get().to(|| async { HttpResponse::Ok().json("Hello World") }),
+        )
     })
     .bind("127.0.0.1:8080")?
     .run()
     .await
 }
 """
+
+RUST_MAIN_WITH_CLIENTS_CONTENT = f"""mod clients;
+
+{RUST_MAIN_CONTENT}"""
 
 CPP_ROUTES_HEADER_CONTENT = """#pragma once
 
@@ -81,15 +88,19 @@ LOG_LEVEL=info
 """
 
 
-def rust_service_content_files() -> tuple[ContentFile, ...]:
+def rust_service_content_files(*, include_redis_cache: bool = False) -> tuple[ContentFile, ...]:
     """Return direct content files for Rust services."""
-    return (
+    main_content = RUST_MAIN_WITH_CLIENTS_CONTENT if include_redis_cache else RUST_MAIN_CONTENT
+    files = (
         ContentFile("src/api/mod.rs", RUST_MODULE_CONTENT),
         ContentFile("src/model/mod.rs", RUST_MODULE_CONTENT),
         ContentFile("tests/api/mod.rs", RUST_MODULE_CONTENT),
         ContentFile("tests/model/mod.rs", RUST_MODULE_CONTENT),
-        ContentFile("src/main.rs", RUST_MAIN_CONTENT),
+        ContentFile("src/main.rs", main_content),
     )
+    if include_redis_cache:
+        return (*files, ContentFile("src/clients/mod.rs", RUST_CLIENTS_MODULE_CONTENT))
+    return files
 
 
 def cpp_service_content_files() -> tuple[ContentFile, ...]:

--- a/src/generator/service.py
+++ b/src/generator/service.py
@@ -368,7 +368,16 @@ class ServiceGenerator(BaseGenerator):
         - Cargo.toml with common dependencies
         - Proper crate structure
         """
-        self._write_content_files(rust_service_content_files())
+        include_redis_cache = self.cache == "redis"
+        self._write_content_files(rust_service_content_files(include_redis_cache=include_redis_cache))
+        if include_redis_cache:
+            self.write_template("src/clients/cache.rs", "rust/extensions/cache/redis.rs.tpl")
+            self.write_content(
+                ".env.example",
+                "EXAMPLE_ENV_VAR=value\nREDIS_URL=redis://127.0.0.1:6379/0\n",
+            )
+            self.write_template("Cargo.toml", "rust/Cargo.toml.tpl", cache="redis")
+            return
         self.write_template("Cargo.toml", "rust/Cargo.toml.tpl")
 
     def _create_cpp_structure(self) -> None:

--- a/src/generator/service_capabilities.py
+++ b/src/generator/service_capabilities.py
@@ -36,7 +36,10 @@ _SERVICE_EXTENSION_SUPPORT: dict[tuple[str, str, str], ServiceExtensionSupport] 
         databases=IMPLEMENTED_DATABASE_EXTENSIONS,
         caches=IMPLEMENTED_CACHE_EXTENSIONS,
         auth=IMPLEMENTED_AUTH_EXTENSIONS,
-    )
+    ),
+    ("rust", "container", "default"): ServiceExtensionSupport(
+        caches=IMPLEMENTED_CACHE_EXTENSIONS,
+    ),
 }
 
 

--- a/src/templates/rust/Cargo.toml.tpl
+++ b/src/templates/rust/Cargo.toml.tpl
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 actix-web = "4"
+{% if cache == "redis" %}
+redis = { version = "1.2", features = ["tokio-comp"] }
+{% endif %}

--- a/src/templates/rust/README.md.tpl
+++ b/src/templates/rust/README.md.tpl
@@ -23,8 +23,9 @@ make lint
 ```
 src/
 ├── api/          # API endpoints and routes
+├── clients/      # Optional generated service clients
 └── model/        # Data models and structures
 tests/
 ├── api/          # API tests
 └── model/        # Model tests
-``` 
+```

--- a/src/templates/rust/extensions/cache/redis.rs.tpl
+++ b/src/templates/rust/extensions/cache/redis.rs.tpl
@@ -1,0 +1,15 @@
+#![allow(dead_code)]
+
+use redis::{Client, RedisResult, aio::MultiplexedConnection};
+
+pub fn create_client(redis_url: &str) -> RedisResult<Client> {
+    Client::open(redis_url)
+}
+
+pub async fn create_connection(client: &Client) -> RedisResult<MultiplexedConnection> {
+    client.get_multiplexed_async_connection().await
+}
+
+pub async fn ping(connection: &mut MultiplexedConnection) -> RedisResult<String> {
+    redis::cmd("PING").query_async(connection).await
+}

--- a/tests/integration/test_project_creation.py
+++ b/tests/integration/test_project_creation.py
@@ -199,6 +199,30 @@ class TestServiceCreation:
         assert manifest["execution"] == {"models": ["container"], "platforms": ["kubernetes"]}
         assert manifest["artifacts"] == {"image": "dockerfile", "kubernetes": "helm"}
 
+    def test_rust_service_redis_cache_extension(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
+        """Test Rust service generation with Redis cache support."""
+        service_name = "test-rust-redis-service"
+
+        generator = ServiceGenerator(
+            name=service_name,
+            lang="rust",
+            gh=False,
+            config=mock_config,
+            root=str(temp_project_dir),
+            cache="redis",
+        )
+        generator.create()
+
+        project_path = temp_project_dir / service_name
+        manifest = json.loads((project_path / ".kickstart/scaffold.json").read_text())
+
+        assert manifest["capabilities"] == {"service_extensions": {"cache": "redis"}}
+        assert (project_path / "src/clients/mod.rs").read_text() == "pub mod cache;\n"
+        assert (project_path / "src/clients/cache.rs").exists()
+        assert "mod clients;" in (project_path / "src/main.rs").read_text()
+        assert "redis = " in (project_path / "Cargo.toml").read_text()
+        assert "REDIS_URL=redis://127.0.0.1:6379/0" in (project_path / ".env.example").read_text()
+
     def test_typescript_cloudflare_worker_creation(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
         """Test TypeScript Cloudflare Worker service creation."""
         service_name = "test-worker-service"

--- a/tests/unit/generator/test_service.py
+++ b/tests/unit/generator/test_service.py
@@ -131,11 +131,25 @@ def test_create_passes_service_extension_capabilities_to_manifest(mock_execute_c
     assert contract.service_extensions.auth == "jwt"
 
 
-@pytest.mark.parametrize("language", ["rust", "typescript"])
-def test_create_rejects_unsupported_service_extension_language(language):
+def test_create_rejects_unsupported_typescript_service_cache_extension():
+    language = "typescript"
     generator = ServiceGenerator("test-service", language, False, {}, cache="redis")
 
     with pytest.raises(ExtensionError, match="cache extension 'redis' is not supported"):
+        generator.create()
+
+
+@pytest.mark.parametrize(
+    ("option", "kwargs"),
+    [
+        ("database", {"database": "postgres"}),
+        ("auth", {"auth": "jwt"}),
+    ],
+)
+def test_create_rejects_unsupported_rust_service_extension_categories(option, kwargs):
+    generator = ServiceGenerator("test-service", "rust", False, {}, **kwargs)
+
+    with pytest.raises(ExtensionError, match=f"{option} extension '.+' is not supported"):
         generator.create()
 
 
@@ -254,11 +268,26 @@ def test_create_rust_structure(mock_write_content, mock_write_template, service_
     ]
     
     # Verify main.rs is created
-    expected_main_content = "use actix_web::{web, App, HttpResponse, HttpServer};\n\n#[actix_web::main]\nasync fn main() -> std::io::Result<()> {\n    HttpServer::new(|| {\n        App::new()\n            .route(\"/\", web::get().to(|| async { HttpResponse::Ok().json(\"Hello World\") }))\n    })\n    .bind(\"127.0.0.1:8080\")?\n    .run()\n    .await\n}\n"
+    expected_main_content = "use actix_web::{App, HttpResponse, HttpServer, web};\n\n#[actix_web::main]\nasync fn main() -> std::io::Result<()> {\n    HttpServer::new(|| {\n        App::new().route(\n            \"/\",\n            web::get().to(|| async { HttpResponse::Ok().json(\"Hello World\") }),\n        )\n    })\n    .bind(\"127.0.0.1:8080\")?\n    .run()\n    .await\n}\n"
     expected_main_call = call("src/main.rs", expected_main_content)
     
     mock_write_content.assert_has_calls(expected_mod_calls + [expected_main_call], any_order=True)
     mock_write_template.assert_called_once_with("Cargo.toml", "rust/Cargo.toml.tpl")
+
+
+@patch.object(ServiceGenerator, 'write_template')
+@patch.object(ServiceGenerator, 'write_content')
+def test_create_rust_structure_with_redis_cache(mock_write_content, mock_write_template, service_generator):
+    generator = ServiceGenerator("test-service", "rust", False, {}, cache="redis")
+    generator._create_rust_structure()
+
+    mock_write_content.assert_any_call("src/clients/mod.rs", "pub mod cache;\n")
+    mock_write_content.assert_any_call(
+        ".env.example",
+        "EXAMPLE_ENV_VAR=value\nREDIS_URL=redis://127.0.0.1:6379/0\n",
+    )
+    mock_write_template.assert_any_call("src/clients/cache.rs", "rust/extensions/cache/redis.rs.tpl")
+    mock_write_template.assert_any_call("Cargo.toml", "rust/Cargo.toml.tpl", cache="redis")
 
 
 @patch.object(ServiceGenerator, 'write_content')

--- a/tests/unit/generator/test_service_capabilities.py
+++ b/tests/unit/generator/test_service_capabilities.py
@@ -21,16 +21,50 @@ def test_python_fastapi_container_accepts_implemented_extensions() -> None:
     assert selection.auth == "jwt"
 
 
-@pytest.mark.parametrize("language", ["rust", "typescript"])
-def test_non_python_services_reject_current_python_only_extensions(language: str) -> None:
-    with pytest.raises(ExtensionError, match=rf"{language}/container/default"):
+def test_rust_container_accepts_redis_cache_extension() -> None:
+    selection = validate_service_extensions(
+        language="rust",
+        runtime="container",
+        framework=None,
+        database=None,
+        cache="redis",
+        auth=None,
+    )
+
+    assert selection.database is None
+    assert selection.cache == "redis"
+    assert selection.auth is None
+
+
+def test_typescript_services_reject_redis_until_templates_exist() -> None:
+    with pytest.raises(ExtensionError, match="typescript/container/default"):
         validate_service_extensions(
-            language=language,
+            language="typescript",
             runtime="container",
             framework=None,
             database=None,
             cache="redis",
             auth=None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("category", "kwargs"),
+    [
+        ("database", {"database": "postgres", "cache": None, "auth": None}),
+        ("auth", {"database": None, "cache": None, "auth": "jwt"}),
+    ],
+)
+def test_rust_container_rejects_unimplemented_extension_categories(
+    category: str,
+    kwargs: dict[str, str | None],
+) -> None:
+    with pytest.raises(ExtensionError, match=rf"{category} extension '.+' is not supported"):
+        validate_service_extensions(
+            language="rust",
+            runtime="container",
+            framework=None,
+            **kwargs,
         )
 
 


### PR DESCRIPTION
Closes #35.

Stacked on #48 / `feature/service-extension-capabilities`.

## What changed

- Added Rust/container `--cache redis` to the service extension capability matrix.
- Generated `src/clients/cache.rs` and `src/clients/mod.rs` for Rust Redis services.
- Rendered the Redis crate dependency into Rust `Cargo.toml` only when `--cache redis` is selected.
- Added `REDIS_URL` to generated `.env.example` for Rust Redis services.
- Updated README/docs/CLI help so the supported extension matrix is truthful.
- Kept unsupported combinations loud: TypeScript Redis and Rust JWT/Postgres still fail until their feature branches land.

## Evidence

- `make check` in kickstart: Ruff passed, mypy passed on 36 source files, `240 passed in 2.25s`.
- Generated sample: `poetry run kickstart create service rust-redis-api --root /private/tmp/kickstart-rust-redis-evidence-03 --lang rust --cache redis`.
- Generated sample files included `src/clients/cache.rs`, `src/clients/mod.rs`, `REDIS_URL`, Redis Cargo dependency, and `.kickstart/scaffold.json` with `capabilities.service_extensions.cache = redis`.
- Generated Rust service `make check`: `cargo fmt --all -- --check`, `cargo fetch`, `cargo check`, and `cargo test` all passed.
- Negative checks:
  - `poetry run kickstart create service ts-redis-api --root /private/tmp/kickstart-rust-redis-evidence-03 --lang typescript --cache redis` failed with unsupported TypeScript Redis message.
  - `poetry run kickstart create service rust-auth-api --root /private/tmp/kickstart-rust-redis-evidence-03 --lang rust --auth jwt` failed with unsupported Rust JWT message.