### PR TITLE
[codex] Add Redis cache support for TypeScript services

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ poetry run kickstart create mono product-stack
 - Preferred stack: Rust, TypeScript, Python, SQL, and C++.
 - Go is supported as a tolerated service target; Python and Rust are the first-class library/CLI targets.
 - Service execution models: containers by default, Cloudflare Workers when requested.
-- Implemented service extensions are intentionally narrow: Python/FastAPI container services support Postgres, Redis, and JWT; Rust container services support Redis and JWT; TypeScript container services support Postgres.
+- Implemented service extensions are intentionally narrow: Python/FastAPI container services support Postgres, Redis, and JWT; Rust container services support Redis and JWT; TypeScript container services support Postgres and Redis.
 - System provider targets: `multi`, `aws`, `gcp`, `cloudflare`, or `none`.
 - System platform profiles: `kubernetes`, `cloudflare-workers`, or `hybrid`.
 - Dockerfiles are image artifacts; Helm and Kustomize are Kubernetes artifact styles; Wrangler is the Cloudflare Worker artifact path.
@@ -54,7 +54,7 @@ poetry run kickstart create mono product-stack
 ```bash
 poetry run kickstart create service my-api --lang python --database postgres --cache redis --auth jwt
 poetry run kickstart create service api-rs --lang rust --cache redis --auth jwt
-poetry run kickstart create service api-ts --lang typescript --database postgres
+poetry run kickstart create service api-ts --lang typescript --database postgres --cache redis
 poetry run kickstart create service edge-rs --lang rust --runtime cloudflare-workers
 poetry run kickstart create frontend web
 poetry run kickstart create lib core-lib --lang python

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -52,7 +52,7 @@ Implemented service extensions are intentionally narrow. As of this contract:
 
 - Python/FastAPI container services support `postgres`, `redis`, and `jwt`.
 - Rust container services support `redis` and `jwt`.
-- TypeScript container services support `postgres`.
+- TypeScript container services support `postgres` and `redis`.
 
 Do not pass unsupported extension options and assume they were generated.
 

--- a/docs/human-guide.md
+++ b/docs/human-guide.md
@@ -37,7 +37,7 @@ Support is intentionally narrow:
 
 - Python/FastAPI container services support Postgres, Redis, and JWT.
 - Rust container services support Redis and JWT.
-- TypeScript container services support Postgres.
+- TypeScript container services support Postgres and Redis.
 
 Other language/runtime/framework combinations fail loudly until their templates are implemented.
 

--- a/docs/scaffold-contract.md
+++ b/docs/scaffold-contract.md
@@ -26,7 +26,7 @@ There is no separate root architecture document. `docs/architecture/` is the can
 - `capabilities`: optional generated capabilities with real code support, for example `service_extensions: { database: postgres, cache: redis, auth: jwt }`.
 - `knowledge_adapter`: external knowledge integration metadata, for example `none`, `obsidian`, `backstage`, or `both`.
 
-Implemented service extensions are intentionally narrow. Python/FastAPI container services support Postgres, Redis, and JWT. Rust container services support Redis and JWT. TypeScript container services support Postgres. Unsupported combinations fail instead of generating a partial or silent scaffold.
+Implemented service extensions are intentionally narrow. Python/FastAPI container services support Postgres, Redis, and JWT. Rust container services support Redis and JWT. TypeScript container services support Postgres and Redis. Unsupported combinations fail instead of generating a partial or silent scaffold.
 
 Systems contain other project kinds and are currently generated through the `mono` command with `project.repo_layout: monorepo`.
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -150,7 +150,7 @@ def create(
     cache: Optional[str] = typer.Option(
         None,
         "--cache",
-        help="Cache extension (implemented: redis for Python/FastAPI and Rust container services)",
+        help="Cache extension (implemented: redis for Python/FastAPI, Rust, and TypeScript container services)",
     ),
     auth: Optional[str] = typer.Option(
         None,

--- a/src/cli/prompts.py
+++ b/src/cli/prompts.py
@@ -96,6 +96,11 @@ def prompt_for_missing_args(
             if database == "none":
                 database = None
 
+        if lang in ("typescript", "ts") and cache is None:
+            cache = prompt.ask("Cache extension", choices=["none", "redis"], default="none")
+            if cache == "none":
+                cache = None
+
         if lang == "rust":
             if cache is None:
                 cache = prompt.ask("Cache extension", choices=["none", "redis"], default="none")

--- a/src/generator/language_setup.py
+++ b/src/generator/language_setup.py
@@ -84,9 +84,8 @@ PORT=8080
 LOG_LEVEL=info
 """
 
-TYPESCRIPT_POSTGRES_ENV_EXAMPLE_CONTENT = (
-    f"{TYPESCRIPT_ENV_EXAMPLE_CONTENT}DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres\n"
-)
+TYPESCRIPT_POSTGRES_ENV_LINE = "DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres\n"
+TYPESCRIPT_REDIS_ENV_LINE = "REDIS_URL=redis://127.0.0.1:6379/0\n"
 
 
 def rust_service_content_files(
@@ -138,9 +137,17 @@ def go_service_content_files() -> tuple[ContentFile, ...]:
     )
 
 
-def typescript_service_templates(*, include_postgres_database: bool = False) -> tuple[TemplateConfig, ...]:
+def typescript_service_templates(
+    *,
+    include_postgres_database: bool = False,
+    include_redis_cache: bool = False,
+) -> tuple[TemplateConfig, ...]:
     """Return template files for TypeScript services."""
-    template_vars = {"database": "postgres"} if include_postgres_database else {}
+    template_vars: dict[str, str] = {}
+    if include_postgres_database:
+        template_vars["database"] = "postgres"
+    if include_redis_cache:
+        template_vars["cache"] = "redis"
     return (
         TemplateConfig("src/main.ts", "typescript/src/main.ts.tpl", template_vars),
         TemplateConfig("src/config/env.ts", "typescript/src/config/env.ts.tpl", template_vars),
@@ -149,7 +156,15 @@ def typescript_service_templates(*, include_postgres_database: bool = False) -> 
     )
 
 
-def typescript_service_content_files(*, include_postgres_database: bool = False) -> tuple[ContentFile, ...]:
+def typescript_service_content_files(
+    *,
+    include_postgres_database: bool = False,
+    include_redis_cache: bool = False,
+) -> tuple[ContentFile, ...]:
     """Return direct content files for TypeScript services."""
-    env_content = TYPESCRIPT_POSTGRES_ENV_EXAMPLE_CONTENT if include_postgres_database else TYPESCRIPT_ENV_EXAMPLE_CONTENT
+    env_content = TYPESCRIPT_ENV_EXAMPLE_CONTENT
+    if include_postgres_database:
+        env_content += TYPESCRIPT_POSTGRES_ENV_LINE
+    if include_redis_cache:
+        env_content += TYPESCRIPT_REDIS_ENV_LINE
     return (ContentFile(".env.example", env_content),)

--- a/src/generator/service.py
+++ b/src/generator/service.py
@@ -424,13 +424,32 @@ class ServiceGenerator(BaseGenerator):
         a health route, and a small test harness.
         """
         include_postgres_database = self.database == "postgres"
-        self._write_template_configs(typescript_service_templates(include_postgres_database=include_postgres_database))
-        self._write_content_files(typescript_service_content_files(include_postgres_database=include_postgres_database))
+        include_redis_cache = self.cache == "redis"
+        self._write_template_configs(
+            typescript_service_templates(
+                include_postgres_database=include_postgres_database,
+                include_redis_cache=include_redis_cache,
+            )
+        )
+        self._write_content_files(
+            typescript_service_content_files(
+                include_postgres_database=include_postgres_database,
+                include_redis_cache=include_redis_cache,
+            )
+        )
         if include_postgres_database:
             self.write_template("src/clients/database.ts", "typescript/src/clients/database.ts.tpl")
-            self.write_template("package.json", "typescript/package.json.tpl", database="postgres")
             self.create_directories(["migrations"])
             self.write_template("migrations/001_initial.sql", "typescript/extensions/database/migrations.sql.tpl")
+        if include_redis_cache:
+            self.write_template("src/clients/cache.ts", "typescript/src/clients/cache.ts.tpl")
+        if include_postgres_database or include_redis_cache:
+            package_vars: dict[str, str] = {}
+            if include_postgres_database:
+                package_vars["database"] = "postgres"
+            if include_redis_cache:
+                package_vars["cache"] = "redis"
+            self.write_template("package.json", "typescript/package.json.tpl", **package_vars)
 
     def _write_content_files(self, files: Sequence[ContentFile]) -> None:
         """Write direct content files from a typed setup plan."""

--- a/src/generator/service_capabilities.py
+++ b/src/generator/service_capabilities.py
@@ -43,6 +43,7 @@ _SERVICE_EXTENSION_SUPPORT: dict[tuple[str, str, str], ServiceExtensionSupport] 
     ),
     ("typescript", "container", "default"): ServiceExtensionSupport(
         databases=IMPLEMENTED_DATABASE_EXTENSIONS,
+        caches=IMPLEMENTED_CACHE_EXTENSIONS,
     ),
 }
 

--- a/src/templates/typescript/package.json.tpl
+++ b/src/templates/typescript/package.json.tpl
@@ -21,6 +21,9 @@
     "pg": "^8.13.1",
 {% endif %}
     "pino": "^9.6.0",
+{% if cache == "redis" %}
+    "redis": "^5.0.0",
+{% endif %}
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/src/templates/typescript/src/clients/cache.ts.tpl
+++ b/src/templates/typescript/src/clients/cache.ts.tpl
@@ -1,0 +1,24 @@
+import { createClient } from "redis";
+
+export type CacheClient = ReturnType<typeof createClient>;
+
+export function createCacheClient(redisUrl: string): CacheClient {
+  return createClient({ url: redisUrl });
+}
+
+export async function connectCacheClient(client: CacheClient): Promise<CacheClient> {
+  if (!client.isOpen) {
+    await client.connect();
+  }
+  return client;
+}
+
+export async function ping(client: CacheClient): Promise<string> {
+  return client.ping();
+}
+
+export async function closeCacheClient(client: CacheClient): Promise<void> {
+  if (client.isOpen) {
+    await client.quit();
+  }
+}

--- a/src/templates/typescript/src/config/env.ts.tpl
+++ b/src/templates/typescript/src/config/env.ts.tpl
@@ -7,6 +7,9 @@ const envSchema = z.object({
 {% if database == "postgres" %}
   DATABASE_URL: z.string().url().default("postgres://postgres:postgres@127.0.0.1:5432/postgres"),
 {% endif %}
+{% if cache == "redis" %}
+  REDIS_URL: z.string().url().default("redis://127.0.0.1:6379/0"),
+{% endif %}
 });
 
 export const env = envSchema.parse(process.env);

--- a/tests/integration/test_project_creation.py
+++ b/tests/integration/test_project_creation.py
@@ -273,6 +273,29 @@ class TestServiceCreation:
             project_path / ".env.example"
         ).read_text()
 
+    def test_typescript_service_redis_cache_extension(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
+        """Test TypeScript service generation with Redis cache support."""
+        service_name = "test-typescript-redis-service"
+
+        generator = ServiceGenerator(
+            name=service_name,
+            lang="typescript",
+            gh=False,
+            config=mock_config,
+            root=str(temp_project_dir),
+            cache="redis",
+        )
+        generator.create()
+
+        project_path = temp_project_dir / service_name
+        manifest = json.loads((project_path / ".kickstart/scaffold.json").read_text())
+
+        assert manifest["capabilities"] == {"service_extensions": {"cache": "redis"}}
+        assert (project_path / "src/clients/cache.ts").exists()
+        assert '"redis": "^5.0.0"' in (project_path / "package.json").read_text()
+        assert "REDIS_URL: z.string().url()" in (project_path / "src/config/env.ts").read_text()
+        assert "REDIS_URL=redis://127.0.0.1:6379/0" in (project_path / ".env.example").read_text()
+
     def test_typescript_cloudflare_worker_creation(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
         """Test TypeScript Cloudflare Worker service creation."""
         service_name = "test-worker-service"

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -274,7 +274,7 @@ def test_create_interactive_typescript_service_can_select_postgres(
 ):
     """Test selecting Postgres for a TypeScript service interactively."""
     mock_load_config.return_value = mock_config
-    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "typescript", "postgres"]
+    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "typescript", "postgres", "none"]
     mock_confirm.ask.side_effect = [False, False]
 
     result = runner.invoke(app, ["create"])
@@ -282,6 +282,31 @@ def test_create_interactive_typescript_service_can_select_postgres(
     assert result.exit_code == 0
     mock_create_service.assert_called_once_with(
         "my-service", "typescript", False, mock_config, helm=False, root="/tmp", database="postgres"
+    )
+
+
+@patch('src.cli.main.create_service')
+@patch('src.cli.main.load_config')
+@patch('src.cli.main.Confirm')
+@patch('src.cli.main.Prompt')
+def test_create_interactive_typescript_service_can_select_redis(
+    mock_prompt,
+    mock_confirm,
+    mock_load_config,
+    mock_create_service,
+    runner,
+    mock_config,
+):
+    """Test selecting Redis for a TypeScript service interactively."""
+    mock_load_config.return_value = mock_config
+    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "typescript", "none", "redis"]
+    mock_confirm.ask.side_effect = [False, False]
+
+    result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 0
+    mock_create_service.assert_called_once_with(
+        "my-service", "typescript", False, mock_config, helm=False, root="/tmp", cache="redis"
     )
 
 

--- a/tests/unit/generator/test_service.py
+++ b/tests/unit/generator/test_service.py
@@ -131,9 +131,8 @@ def test_create_passes_service_extension_capabilities_to_manifest(mock_execute_c
     assert contract.service_extensions.auth == "jwt"
 
 
-def test_create_rejects_unsupported_typescript_service_cache_extension():
-    language = "typescript"
-    generator = ServiceGenerator("test-service", language, False, {}, cache="redis")
+def test_create_rejects_unsupported_go_service_cache_extension():
+    generator = ServiceGenerator("test-service", "go", False, {}, cache="redis")
 
     with pytest.raises(ExtensionError, match="cache extension 'redis' is not supported"):
         generator.create()
@@ -154,6 +153,19 @@ def test_create_rejects_unsupported_typescript_service_auth_extension():
 )
 def test_create_rejects_unsupported_rust_service_extension_categories(option, kwargs):
     generator = ServiceGenerator("test-service", "rust", False, {}, **kwargs)
+
+    with pytest.raises(ExtensionError, match=f"{option} extension '.+' is not supported"):
+        generator.create()
+
+
+@pytest.mark.parametrize(
+    ("option", "kwargs"),
+    [
+        ("auth", {"auth": "jwt"}),
+    ],
+)
+def test_create_rejects_unsupported_typescript_service_extension_categories(option, kwargs):
+    generator = ServiceGenerator("test-service", "typescript", False, {}, **kwargs)
 
     with pytest.raises(ExtensionError, match=f"{option} extension '.+' is not supported"):
         generator.create()
@@ -574,6 +586,20 @@ def test_create_typescript_structure_with_postgres_database(
         "DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres\n",
     )
     mock_create_directories.assert_called_once_with(["migrations"])
+
+
+@patch.object(ServiceGenerator, 'write_content')
+@patch.object(ServiceGenerator, 'write_template')
+def test_create_typescript_structure_with_redis_cache(mock_write_template, mock_write_content, service_generator):
+    generator = ServiceGenerator("test-service", "typescript", False, {}, cache="redis")
+    generator._create_typescript_structure()
+
+    mock_write_template.assert_any_call("src/clients/cache.ts", "typescript/src/clients/cache.ts.tpl")
+    mock_write_template.assert_any_call("package.json", "typescript/package.json.tpl", cache="redis")
+    mock_write_content.assert_called_once_with(
+        ".env.example",
+        "HOST=0.0.0.0\nPORT=8080\nLOG_LEVEL=info\nREDIS_URL=redis://127.0.0.1:6379/0\n",
+    )
 
 
 def test_typescript_alias_normalizes_to_template_directory():

--- a/tests/unit/generator/test_service_capabilities.py
+++ b/tests/unit/generator/test_service_capabilities.py
@@ -66,16 +66,19 @@ def test_typescript_container_accepts_postgres_database_extension() -> None:
     assert selection.auth is None
 
 
-def test_typescript_services_reject_redis_until_templates_exist() -> None:
-    with pytest.raises(ExtensionError, match="typescript/container/default"):
-        validate_service_extensions(
-            language="typescript",
-            runtime="container",
-            framework=None,
-            database=None,
-            cache="redis",
-            auth=None,
-        )
+def test_typescript_container_accepts_redis_cache_extension() -> None:
+    selection = validate_service_extensions(
+        language="typescript",
+        runtime="container",
+        framework=None,
+        database=None,
+        cache="redis",
+        auth=None,
+    )
+
+    assert selection.database is None
+    assert selection.cache == "redis"
+    assert selection.auth is None
 
 
 def test_typescript_services_reject_jwt_until_templates_exist() -> None:
@@ -109,6 +112,25 @@ def test_rust_container_rejects_unimplemented_extension_categories(
         )
 
 
+@pytest.mark.parametrize(
+    ("category", "kwargs"),
+    [
+        ("auth", {"database": None, "cache": None, "auth": "jwt"}),
+    ],
+)
+def test_typescript_container_rejects_unimplemented_extension_categories(
+    category: str,
+    kwargs: dict[str, str | None],
+) -> None:
+    with pytest.raises(ExtensionError, match=rf"{category} extension '.+' is not supported"):
+        validate_service_extensions(
+            language="typescript",
+            runtime="container",
+            framework=None,
+            **kwargs,
+        )
+
+
 def test_cloudflare_worker_services_reject_extensions() -> None:
     with pytest.raises(ExtensionError, match="auth extension 'jwt' is not supported"):
         validate_service_extensions(
@@ -130,23 +152,4 @@ def test_python_minimal_services_reject_extensions() -> None:
             database="postgres",
             cache=None,
             auth=None,
-        )
-
-
-@pytest.mark.parametrize(
-    ("category", "value", "kwargs"),
-    [
-        ("database", "mysql", {"database": "mysql", "cache": None, "auth": None}),
-        ("database", "sqlite", {"database": "sqlite", "cache": None, "auth": None}),
-        ("cache", "memcached", {"database": None, "cache": "memcached", "auth": None}),
-        ("auth", "oauth", {"database": None, "cache": None, "auth": "oauth"}),
-    ],
-)
-def test_unimplemented_extension_values_reject(category: str, value: str, kwargs: dict[str, str | None]) -> None:
-    with pytest.raises(ExtensionError, match=f"{category} extension '{value}' is not implemented"):
-        validate_service_extensions(
-            language="python",
-            runtime="container",
-            framework=None,
-            **kwargs,
         )


### PR DESCRIPTION
Closes #36.

Stacked on #48 / `feature/service-extension-capabilities`.

## What changed

- Added TypeScript/container `--cache redis` to the service extension capability matrix.
- Generated a typed Redis client at `src/clients/cache.ts` for TypeScript services.
- Rendered the Redis package dependency only when `--cache redis` is selected.
- Added `REDIS_URL` to generated `.env.example` and `src/config/env.ts`.
- Updated CLI help, interactive prompts, README, and docs to describe the supported TypeScript Redis capability.
- Kept unsupported combinations loud: Rust Redis and TypeScript JWT/Postgres still fail on this branch until their feature branches land.

## Evidence

- `make check` in kickstart: Ruff passed, mypy passed on 36 source files, `241 passed in 2.11s`.
- Generated sample: `poetry run kickstart create service ts-redis-api --root /private/tmp/kickstart-ts-redis-evidence-01 --lang typescript --cache redis`.
- Generated sample files included `src/clients/cache.ts`, `REDIS_URL`, Redis package dependency, and `.kickstart/scaffold.json` with `capabilities.service_extensions.cache = redis`.
- Generated TypeScript service `make check`: `bun install`, `bun run typecheck`, and `bun run test` all passed with `1 passed`.
- Negative checks:
  - `poetry run kickstart create service rust-redis-api --root /private/tmp/kickstart-ts-redis-evidence-01 --lang rust --cache redis` failed with unsupported Rust Redis message.
  - `poetry run kickstart create service ts-auth-api --root /private/tmp/kickstart-ts-redis-evidence-01 --lang typescript --auth jwt` failed with unsupported TypeScript JWT message.