### PR TITLE
[codex] Add Postgres support for Rust services

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ poetry run kickstart create mono product-stack
 - Preferred stack: Rust, TypeScript, Python, SQL, and C++.
 - Go is supported as a tolerated service target; Python and Rust are the first-class library/CLI targets.
 - Service execution models: containers by default, Cloudflare Workers when requested.
-- Implemented service extensions are intentionally narrow: Python/FastAPI container services support Postgres, Redis, and JWT; Rust container services support Redis and JWT; TypeScript container services support Postgres and Redis.
+- Implemented service extensions are intentionally narrow: Python/FastAPI container services support Postgres, Redis, and JWT; Rust container services support Postgres, Redis, and JWT; TypeScript container services support Postgres and Redis.
 - System provider targets: `multi`, `aws`, `gcp`, `cloudflare`, or `none`.
 - System platform profiles: `kubernetes`, `cloudflare-workers`, or `hybrid`.
 - Dockerfiles are image artifacts; Helm and Kustomize are Kubernetes artifact styles; Wrangler is the Cloudflare Worker artifact path.
@@ -53,7 +53,7 @@ poetry run kickstart create mono product-stack
 
 ```bash
 poetry run kickstart create service my-api --lang python --database postgres --cache redis --auth jwt
-poetry run kickstart create service api-rs --lang rust --cache redis --auth jwt
+poetry run kickstart create service api-rs --lang rust --database postgres --cache redis --auth jwt
 poetry run kickstart create service api-ts --lang typescript --database postgres --cache redis
 poetry run kickstart create service edge-rs --lang rust --runtime cloudflare-workers
 poetry run kickstart create frontend web

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -51,7 +51,7 @@ Do not infer unsupported options. Use existing registries and typed plans.
 Implemented service extensions are intentionally narrow. As of this contract:
 
 - Python/FastAPI container services support `postgres`, `redis`, and `jwt`.
-- Rust container services support `redis` and `jwt`.
+- Rust container services support `postgres`, `redis`, and `jwt`.
 - TypeScript container services support `postgres` and `redis`.
 
 Do not pass unsupported extension options and assume they were generated.

--- a/docs/human-guide.md
+++ b/docs/human-guide.md
@@ -36,7 +36,7 @@ Implemented service extensions:
 Support is intentionally narrow:
 
 - Python/FastAPI container services support Postgres, Redis, and JWT.
-- Rust container services support Redis and JWT.
+- Rust container services support Postgres, Redis, and JWT.
 - TypeScript container services support Postgres and Redis.
 
 Other language/runtime/framework combinations fail loudly until their templates are implemented.

--- a/docs/scaffold-contract.md
+++ b/docs/scaffold-contract.md
@@ -26,7 +26,7 @@ There is no separate root architecture document. `docs/architecture/` is the can
 - `capabilities`: optional generated capabilities with real code support, for example `service_extensions: { database: postgres, cache: redis, auth: jwt }`.
 - `knowledge_adapter`: external knowledge integration metadata, for example `none`, `obsidian`, `backstage`, or `both`.
 
-Implemented service extensions are intentionally narrow. Python/FastAPI container services support Postgres, Redis, and JWT. Rust container services support Redis and JWT. TypeScript container services support Postgres and Redis. Unsupported combinations fail instead of generating a partial or silent scaffold.
+Implemented service extensions are intentionally narrow. Python/FastAPI container services support Postgres, Redis, and JWT. Rust container services support Postgres, Redis, and JWT. TypeScript container services support Postgres and Redis. Unsupported combinations fail instead of generating a partial or silent scaffold.
 
 Systems contain other project kinds and are currently generated through the `mono` command with `project.repo_layout: monorepo`.
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -145,7 +145,7 @@ def create(
     database: Optional[str] = typer.Option(
         None,
         "--database",
-        help="Database extension (implemented: postgres for Python/FastAPI and TypeScript container services)",
+        help="Database extension (implemented: postgres for Python/FastAPI, Rust, and TypeScript container services)",
     ),
     cache: Optional[str] = typer.Option(
         None,

--- a/src/cli/prompts.py
+++ b/src/cli/prompts.py
@@ -91,7 +91,7 @@ def prompt_for_missing_args(
                 if framework == "fastapi":
                     framework = None
 
-        if lang in ("typescript", "ts") and database is None:
+        if lang in ("typescript", "ts", "rust") and database is None:
             database = prompt.ask("Database extension", choices=["none", "postgres"], default="none")
             if database == "none":
                 database = None

--- a/src/generator/language_setup.py
+++ b/src/generator/language_setup.py
@@ -14,7 +14,6 @@ class ContentFile:
 
 
 RUST_MODULE_CONTENT = "// Module definitions\n"
-RUST_CLIENTS_MODULE_CONTENT = "pub mod cache;\n"
 RUST_HANDLER_MODULE_CONTENT = "pub mod auth;\n"
 
 RUST_MAIN_CONTENT = """use actix_web::{App, HttpResponse, HttpServer, web};
@@ -90,15 +89,17 @@ TYPESCRIPT_REDIS_ENV_LINE = "REDIS_URL=redis://127.0.0.1:6379/0\n"
 
 def rust_service_content_files(
     *,
+    include_postgres_database: bool = False,
     include_redis_cache: bool = False,
     include_jwt_auth: bool = False,
 ) -> tuple[ContentFile, ...]:
     """Return direct content files for Rust services."""
     module_lines = []
-    if include_redis_cache:
+    if include_postgres_database or include_redis_cache:
         module_lines.append("mod clients;")
     if include_jwt_auth:
         module_lines.append("mod handler;")
+
     main_content = RUST_MAIN_CONTENT
     if module_lines:
         main_content = "\n".join(module_lines) + f"\n\n{RUST_MAIN_CONTENT}"
@@ -110,8 +111,14 @@ def rust_service_content_files(
         ContentFile("tests/model/mod.rs", RUST_MODULE_CONTENT),
         ContentFile("src/main.rs", main_content),
     )
+
+    client_module_lines = []
     if include_redis_cache:
-        files = (*files, ContentFile("src/clients/mod.rs", RUST_CLIENTS_MODULE_CONTENT))
+        client_module_lines.append("pub mod cache;")
+    if include_postgres_database:
+        client_module_lines.append("pub mod database;")
+    if client_module_lines:
+        files = (*files, ContentFile("src/clients/mod.rs", "\n".join(client_module_lines) + "\n"))
     if include_jwt_auth:
         files = (*files, ContentFile("src/handler/mod.rs", RUST_HANDLER_MODULE_CONTENT))
     return files

--- a/src/generator/service.py
+++ b/src/generator/service.py
@@ -368,28 +368,38 @@ class ServiceGenerator(BaseGenerator):
         - Cargo.toml with common dependencies
         - Proper crate structure
         """
+        include_postgres_database = self.database == "postgres"
         include_redis_cache = self.cache == "redis"
         include_jwt_auth = self.auth == "jwt"
         self._write_content_files(
             rust_service_content_files(
+                include_postgres_database=include_postgres_database,
                 include_redis_cache=include_redis_cache,
                 include_jwt_auth=include_jwt_auth,
             )
         )
+        if include_postgres_database:
+            self.write_template("src/clients/database.rs", "rust/extensions/database/postgres.rs.tpl")
+            self.create_directories(["migrations"])
+            self.write_template("migrations/001_initial.sql", "rust/extensions/database/migrations.sql.tpl")
         if include_redis_cache:
             self.write_template("src/clients/cache.rs", "rust/extensions/cache/redis.rs.tpl")
         if include_jwt_auth:
             self.write_template("src/handler/auth.rs", "rust/extensions/auth/jwt.rs.tpl")
 
-        if include_redis_cache or include_jwt_auth:
+        if include_postgres_database or include_redis_cache or include_jwt_auth:
             env_content = "EXAMPLE_ENV_VAR=value\n"
+            if include_postgres_database:
+                env_content += "DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres\n"
             if include_redis_cache:
                 env_content += "REDIS_URL=redis://127.0.0.1:6379/0\n"
             if include_jwt_auth:
                 env_content += f"JWT_SECRET=change-me-change-me\nJWT_ISSUER={self.name}\n"
             self.write_content(".env.example", env_content)
 
-        cargo_vars = {}
+        cargo_vars: dict[str, str] = {}
+        if include_postgres_database:
+            cargo_vars["database"] = "postgres"
         if include_redis_cache:
             cargo_vars["cache"] = "redis"
         if include_jwt_auth:

--- a/src/generator/service_capabilities.py
+++ b/src/generator/service_capabilities.py
@@ -38,6 +38,7 @@ _SERVICE_EXTENSION_SUPPORT: dict[tuple[str, str, str], ServiceExtensionSupport] 
         auth=IMPLEMENTED_AUTH_EXTENSIONS,
     ),
     ("rust", "container", "default"): ServiceExtensionSupport(
+        databases=IMPLEMENTED_DATABASE_EXTENSIONS,
         caches=IMPLEMENTED_CACHE_EXTENSIONS,
         auth=IMPLEMENTED_AUTH_EXTENSIONS,
     ),

--- a/src/templates/python/core/model/dto/requests.py.tpl
+++ b/src/templates/python/core/model/dto/requests.py.tpl
@@ -13,6 +13,78 @@ from models.entities.user.user import User
 from models.entities.user.profile import Gender, ProfileVisibility
 
 
+def _require_string(data: Dict[str, object], field_name: str) -> str:
+    """Get a required string field from request data."""
+    value = data.get(field_name)
+    if isinstance(value, str):
+        return value
+    raise ValueError(f"'{field_name}' must be a string")
+
+
+def _optional_string(data: Dict[str, object], field_name: str) -> Optional[str]:
+    """Get an optional string field from request data."""
+    value = data.get(field_name)
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    raise ValueError(f"'{field_name}' must be a string when provided")
+
+
+def _optional_object_dict(data: Dict[str, object], field_name: str) -> Optional[Dict[str, object]]:
+    """Get an optional dictionary with string keys from request data."""
+    value = data.get(field_name)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"'{field_name}' must be a dictionary when provided")
+
+    normalized: Dict[str, object] = {}
+    for item_key, item_value in value.items():
+        if not isinstance(item_key, str):
+            raise ValueError(f"'{field_name}' keys must be strings")
+        normalized[item_key] = item_value
+    return normalized
+
+
+def _optional_date(data: Dict[str, object], field_name: str) -> Optional[date]:
+    """Get an optional ISO date field from request data."""
+    value = data.get(field_name)
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return date.fromisoformat(value)
+    raise ValueError(f"'{field_name}' must be an ISO date string or date")
+
+
+def _optional_string_list(data: Dict[str, object], field_name: str) -> Optional[List[str]]:
+    """Get an optional list of strings from request data."""
+    value = data.get(field_name)
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise ValueError(f"'{field_name}' must be a list when provided")
+
+    normalized: List[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueError(f"'{field_name}' items must be strings")
+        normalized.append(item)
+    return normalized
+
+
+def _int_with_default(data: Dict[str, object], field_name: str, default: int) -> int:
+    """Get an integer value from request data, using a default when absent."""
+    value = data.get(field_name, default)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        return int(value)
+    raise ValueError(f"'{field_name}' must be an integer")
+
+
 @dataclass
 class CreateUserRequest:
     """Request DTO for creating a new user.
@@ -51,11 +123,11 @@ class CreateUserRequest:
             CreateUserRequest instance
         """
         return cls(
-            username=data['username'],
-            email=data['email'],
-            full_name=data['full_name'],
-            password=data['password'],
-            profile_data=data.get('profile_data')
+            username=_require_string(data, 'username'),
+            email=_require_string(data, 'email'),
+            full_name=_require_string(data, 'full_name'),
+            password=_require_string(data, 'password'),
+            profile_data=_optional_object_dict(data, 'profile_data')
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -94,10 +166,10 @@ class UpdateUserRequest:
             UpdateUserRequest instance
         """
         return cls(
-            username=data.get('username'),
-            email=data.get('email'),
-            full_name=data.get('full_name'),
-            profile_data=data.get('profile_data')
+            username=_optional_string(data, 'username'),
+            email=_optional_string(data, 'email'),
+            full_name=_optional_string(data, 'full_name'),
+            profile_data=_optional_object_dict(data, 'profile_data')
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -145,9 +217,9 @@ class ChangePasswordRequest:
             ChangePasswordRequest instance
         """
         return cls(
-            current_password=data['current_password'],
-            new_password=data['new_password'],
-            confirm_password=data['confirm_password']
+            current_password=_require_string(data, 'current_password'),
+            new_password=_require_string(data, 'new_password'),
+            confirm_password=_require_string(data, 'confirm_password')
         )
 
     def validate_passwords_match(self) -> bool:
@@ -233,39 +305,33 @@ class CreateUserProfileRequest:
         Returns:
             CreateUserProfileRequest instance
         """
-        # Parse date of birth if provided
-        date_of_birth = None
-        if data.get('date_of_birth'):
-            if isinstance(data['date_of_birth'], str):
-                date_of_birth = date.fromisoformat(data['date_of_birth'])
-            else:
-                date_of_birth = data['date_of_birth']
+        date_of_birth = _optional_date(data, 'date_of_birth')
 
         return cls(
-            bio=data.get('bio'),
-            avatar_url=data.get('avatar_url'),
+            bio=_optional_string(data, 'bio'),
+            avatar_url=_optional_string(data, 'avatar_url'),
             date_of_birth=date_of_birth,
-            gender=data.get('gender'),
-            phone=data.get('phone'),
-            timezone=data.get('timezone'),
-            language=data.get('language'),
-            visibility=data.get('visibility'),
-            twitter=data.get('twitter'),
-            linkedin=data.get('linkedin'),
-            github=data.get('github'),
-            website=data.get('website'),
-            instagram=data.get('instagram'),
-            facebook=data.get('facebook'),
-            street=data.get('street'),
-            city=data.get('city'),
-            state=data.get('state'),
-            country=data.get('country'),
-            postal_code=data.get('postal_code'),
-            interests=data.get('interests'),
-            skills=data.get('skills'),
-            occupation=data.get('occupation'),
-            company=data.get('company'),
-            education=data.get('education')
+            gender=_optional_string(data, 'gender'),
+            phone=_optional_string(data, 'phone'),
+            timezone=_optional_string(data, 'timezone'),
+            language=_optional_string(data, 'language'),
+            visibility=_optional_string(data, 'visibility'),
+            twitter=_optional_string(data, 'twitter'),
+            linkedin=_optional_string(data, 'linkedin'),
+            github=_optional_string(data, 'github'),
+            website=_optional_string(data, 'website'),
+            instagram=_optional_string(data, 'instagram'),
+            facebook=_optional_string(data, 'facebook'),
+            street=_optional_string(data, 'street'),
+            city=_optional_string(data, 'city'),
+            state=_optional_string(data, 'state'),
+            country=_optional_string(data, 'country'),
+            postal_code=_optional_string(data, 'postal_code'),
+            interests=_optional_string_list(data, 'interests'),
+            skills=_optional_string_list(data, 'skills'),
+            occupation=_optional_string(data, 'occupation'),
+            company=_optional_string(data, 'company'),
+            education=_optional_string(data, 'education')
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -327,11 +393,11 @@ class ListUsersRequest:
             ListUsersRequest instance
         """
         return cls(
-            page=max(1, int(data.get('page', 1))),
-            page_size=min(100, max(1, int(data.get('page_size', 20)))),
+            page=max(1, _int_with_default(data, 'page', 1)),
+            page_size=min(100, max(1, _int_with_default(data, 'page_size', 20))),
             active_only=bool(data.get('active_only', True)),
-            search_query=data.get('search_query'),
-            order_by=data.get('order_by'),
+            search_query=_optional_string(data, 'search_query'),
+            order_by=_optional_string(data, 'order_by'),
             order_desc=bool(data.get('order_desc', False))
         )
 
@@ -368,8 +434,8 @@ class SearchUsersRequest:
             SearchUsersRequest instance
         """
         return cls(
-            query=data['query'].strip(),
-            limit=min(100, max(1, int(data.get('limit', 20))))
+            query=_require_string(data, 'query').strip(),
+            limit=min(100, max(1, _int_with_default(data, 'limit', 20)))
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/templates/rust/Cargo.toml.tpl
+++ b/src/templates/rust/Cargo.toml.tpl
@@ -5,6 +5,9 @@ edition = "2024"
 
 [dependencies]
 actix-web = "4"
+{% if database == "postgres" %}
+tokio-postgres = "0.7"
+{% endif %}
 {% if cache == "redis" %}
 redis = { version = "1.2", features = ["tokio-comp"] }
 {% endif %}

--- a/src/templates/rust/extensions/database/migrations.sql.tpl
+++ b/src/templates/rust/extensions/database/migrations.sql.tpl
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS example_records (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/src/templates/rust/extensions/database/postgres.rs.tpl
+++ b/src/templates/rust/extensions/database/postgres.rs.tpl
@@ -1,0 +1,20 @@
+#![allow(dead_code)]
+
+use tokio_postgres::{Client, Error, NoTls};
+
+pub async fn create_client(database_url: &str) -> Result<Client, Error> {
+    let (client, connection) = tokio_postgres::connect(database_url, NoTls).await?;
+
+    actix_web::rt::spawn(async move {
+        if let Err(error) = connection.await {
+            eprintln!("Postgres connection task ended: {error}");
+        }
+    });
+
+    Ok(client)
+}
+
+pub async fn health_check(client: &Client) -> Result<i32, Error> {
+    let row = client.query_one("SELECT 1::INT4", &[]).await?;
+    Ok(row.get(0))
+}

--- a/tests/integration/test_project_creation.py
+++ b/tests/integration/test_project_creation.py
@@ -247,6 +247,33 @@ class TestServiceCreation:
         assert "jsonwebtoken = " in (project_path / "Cargo.toml").read_text()
         assert "JWT_SECRET=change-me-change-me" in (project_path / ".env.example").read_text()
 
+    def test_rust_service_postgres_database_extension(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
+        """Test Rust service generation with Postgres database support."""
+        service_name = "test-rust-postgres-service"
+
+        generator = ServiceGenerator(
+            name=service_name,
+            lang="rust",
+            gh=False,
+            config=mock_config,
+            root=str(temp_project_dir),
+            database="postgres",
+        )
+        generator.create()
+
+        project_path = temp_project_dir / service_name
+        manifest = json.loads((project_path / ".kickstart/scaffold.json").read_text())
+
+        assert manifest["capabilities"] == {"service_extensions": {"database": "postgres"}}
+        assert (project_path / "src/clients/mod.rs").read_text() == "pub mod database;\n"
+        assert (project_path / "src/clients/database.rs").exists()
+        assert (project_path / "migrations/001_initial.sql").exists()
+        assert "mod clients;" in (project_path / "src/main.rs").read_text()
+        assert "tokio-postgres = " in (project_path / "Cargo.toml").read_text()
+        assert "DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres" in (
+            project_path / ".env.example"
+        ).read_text()
+
     def test_typescript_service_postgres_database_extension(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
         """Test TypeScript service generation with Postgres database support."""
         service_name = "test-typescript-postgres-service"

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -224,7 +224,7 @@ def test_create_monorepo_with_runtime(mock_load_config, mock_create_monorepo, ru
 def test_create_interactive_service(mock_prompt, mock_confirm, mock_load_config, mock_create_service, runner, mock_config):
     """Test creating a service interactively."""
     mock_load_config.return_value = mock_config
-    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "rust", "none", "none"]
+    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "rust", "none", "none", "none"]
     mock_confirm.ask.side_effect = [True, True]  # gh=True, helm=True
     
     result = runner.invoke(app, ["create"])
@@ -232,6 +232,31 @@ def test_create_interactive_service(mock_prompt, mock_confirm, mock_load_config,
     assert result.exit_code == 0
     mock_create_service.assert_called_once_with(
         "my-service", "rust", True, mock_config, helm=True, root="/tmp"
+    )
+
+
+@patch('src.cli.main.create_service')
+@patch('src.cli.main.load_config')
+@patch('src.cli.main.Confirm')
+@patch('src.cli.main.Prompt')
+def test_create_interactive_rust_service_can_select_postgres(
+    mock_prompt,
+    mock_confirm,
+    mock_load_config,
+    mock_create_service,
+    runner,
+    mock_config,
+):
+    """Test selecting Postgres for a Rust service interactively."""
+    mock_load_config.return_value = mock_config
+    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "rust", "postgres", "none", "none"]
+    mock_confirm.ask.side_effect = [False, False]
+
+    result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 0
+    mock_create_service.assert_called_once_with(
+        "my-service", "rust", False, mock_config, helm=False, root="/tmp", database="postgres"
     )
 
 
@@ -249,7 +274,7 @@ def test_create_interactive_rust_service_can_select_jwt(
 ):
     """Test selecting JWT for a Rust service interactively."""
     mock_load_config.return_value = mock_config
-    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "rust", "none", "jwt"]
+    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "rust", "none", "none", "jwt"]
     mock_confirm.ask.side_effect = [False, False]
 
     result = runner.invoke(app, ["create"])

--- a/tests/unit/generator/test_service.py
+++ b/tests/unit/generator/test_service.py
@@ -148,19 +148,6 @@ def test_create_rejects_unsupported_typescript_service_auth_extension():
 @pytest.mark.parametrize(
     ("option", "kwargs"),
     [
-        ("database", {"database": "postgres"}),
-    ],
-)
-def test_create_rejects_unsupported_rust_service_extension_categories(option, kwargs):
-    generator = ServiceGenerator("test-service", "rust", False, {}, **kwargs)
-
-    with pytest.raises(ExtensionError, match=f"{option} extension '.+' is not supported"):
-        generator.create()
-
-
-@pytest.mark.parametrize(
-    ("option", "kwargs"),
-    [
         ("auth", {"auth": "jwt"}),
     ],
 )
@@ -341,6 +328,72 @@ def test_create_rust_structure_with_redis_and_jwt(mock_write_content, mock_write
     mock_write_template.assert_any_call("src/clients/cache.rs", "rust/extensions/cache/redis.rs.tpl")
     mock_write_template.assert_any_call("src/handler/auth.rs", "rust/extensions/auth/jwt.rs.tpl")
     mock_write_template.assert_any_call("Cargo.toml", "rust/Cargo.toml.tpl", cache="redis", auth="jwt")
+
+
+@patch.object(ServiceGenerator, 'create_directories')
+@patch.object(ServiceGenerator, 'write_template')
+@patch.object(ServiceGenerator, 'write_content')
+def test_create_rust_structure_with_postgres_database(
+    mock_write_content,
+    mock_write_template,
+    mock_create_directories,
+    service_generator,
+):
+    generator = ServiceGenerator("test-service", "rust", False, {}, database="postgres")
+    generator._create_rust_structure()
+
+    mock_write_content.assert_any_call("src/clients/mod.rs", "pub mod database;\n")
+    mock_write_content.assert_any_call(
+        ".env.example",
+        "EXAMPLE_ENV_VAR=value\nDATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres\n",
+    )
+    mock_write_template.assert_any_call("src/clients/database.rs", "rust/extensions/database/postgres.rs.tpl")
+    mock_write_template.assert_any_call("Cargo.toml", "rust/Cargo.toml.tpl", database="postgres")
+    mock_write_template.assert_any_call("migrations/001_initial.sql", "rust/extensions/database/migrations.sql.tpl")
+    mock_create_directories.assert_called_once_with(["migrations"])
+
+
+@patch.object(ServiceGenerator, 'create_directories')
+@patch.object(ServiceGenerator, 'write_template')
+@patch.object(ServiceGenerator, 'write_content')
+def test_create_rust_structure_with_all_extensions(
+    mock_write_content,
+    mock_write_template,
+    mock_create_directories,
+    service_generator,
+):
+    generator = ServiceGenerator(
+        "test-service",
+        "rust",
+        False,
+        {},
+        database="postgres",
+        cache="redis",
+        auth="jwt",
+    )
+    generator._create_rust_structure()
+
+    mock_write_content.assert_any_call("src/clients/mod.rs", "pub mod cache;\npub mod database;\n")
+    mock_write_content.assert_any_call("src/handler/mod.rs", "pub mod auth;\n")
+    mock_write_content.assert_any_call(
+        ".env.example",
+        "EXAMPLE_ENV_VAR=value\n"
+        "DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/postgres\n"
+        "REDIS_URL=redis://127.0.0.1:6379/0\n"
+        "JWT_SECRET=change-me-change-me\n"
+        "JWT_ISSUER=test-service\n",
+    )
+    mock_write_template.assert_any_call("src/clients/database.rs", "rust/extensions/database/postgres.rs.tpl")
+    mock_write_template.assert_any_call("src/clients/cache.rs", "rust/extensions/cache/redis.rs.tpl")
+    mock_write_template.assert_any_call("src/handler/auth.rs", "rust/extensions/auth/jwt.rs.tpl")
+    mock_write_template.assert_any_call(
+        "Cargo.toml",
+        "rust/Cargo.toml.tpl",
+        database="postgres",
+        cache="redis",
+        auth="jwt",
+    )
+    mock_create_directories.assert_called_once_with(["migrations"])
 
 
 @patch.object(ServiceGenerator, 'write_content')

--- a/tests/unit/generator/test_service_capabilities.py
+++ b/tests/unit/generator/test_service_capabilities.py
@@ -21,62 +21,32 @@ def test_python_fastapi_container_accepts_implemented_extensions() -> None:
     assert selection.auth == "jwt"
 
 
-def test_rust_container_accepts_redis_cache_extension() -> None:
+def test_rust_container_accepts_implemented_extensions() -> None:
     selection = validate_service_extensions(
         language="rust",
         runtime="container",
         framework=None,
-        database=None,
+        database="postgres",
         cache="redis",
-        auth=None,
-    )
-
-    assert selection.database is None
-    assert selection.cache == "redis"
-    assert selection.auth is None
-
-
-def test_rust_container_accepts_jwt_auth_extension() -> None:
-    selection = validate_service_extensions(
-        language="rust",
-        runtime="container",
-        framework=None,
-        database=None,
-        cache=None,
         auth="jwt",
     )
 
-    assert selection.database is None
-    assert selection.cache is None
+    assert selection.database == "postgres"
+    assert selection.cache == "redis"
     assert selection.auth == "jwt"
 
 
-def test_typescript_container_accepts_postgres_database_extension() -> None:
+def test_typescript_container_accepts_database_and_cache_extensions() -> None:
     selection = validate_service_extensions(
         language="typescript",
         runtime="container",
         framework=None,
         database="postgres",
-        cache=None,
-        auth=None,
-    )
-
-    assert selection.database == "postgres"
-    assert selection.cache is None
-    assert selection.auth is None
-
-
-def test_typescript_container_accepts_redis_cache_extension() -> None:
-    selection = validate_service_extensions(
-        language="typescript",
-        runtime="container",
-        framework=None,
-        database=None,
         cache="redis",
         auth=None,
     )
 
-    assert selection.database is None
+    assert selection.database == "postgres"
     assert selection.cache == "redis"
     assert selection.auth is None
 
@@ -90,44 +60,6 @@ def test_typescript_services_reject_jwt_until_templates_exist() -> None:
             database=None,
             cache=None,
             auth="jwt",
-        )
-
-
-@pytest.mark.parametrize(
-    ("category", "kwargs"),
-    [
-        ("database", {"database": "postgres", "cache": None, "auth": None}),
-    ],
-)
-def test_rust_container_rejects_unimplemented_extension_categories(
-    category: str,
-    kwargs: dict[str, str | None],
-) -> None:
-    with pytest.raises(ExtensionError, match=rf"{category} extension '.+' is not supported"):
-        validate_service_extensions(
-            language="rust",
-            runtime="container",
-            framework=None,
-            **kwargs,
-        )
-
-
-@pytest.mark.parametrize(
-    ("category", "kwargs"),
-    [
-        ("auth", {"database": None, "cache": None, "auth": "jwt"}),
-    ],
-)
-def test_typescript_container_rejects_unimplemented_extension_categories(
-    category: str,
-    kwargs: dict[str, str | None],
-) -> None:
-    with pytest.raises(ExtensionError, match=rf"{category} extension '.+' is not supported"):
-        validate_service_extensions(
-            language="typescript",
-            runtime="container",
-            framework=None,
-            **kwargs,
         )
 
 


### PR DESCRIPTION
Closes #37.

Stacked on `feature/service-extension-capabilities` after #53. Merge this before #56.

## What changed

- Added Rust/container `--database postgres` to the service extension capability matrix.
- Generated a typed Postgres client at `src/clients/database.rs` for Rust services.
- Added `DATABASE_URL` to generated `.env.example`.
- Rendered `tokio-postgres` only when `--database postgres` is selected.
- Generated `migrations/001_initial.sql` as a starter schema file.
- Kept Rust service extension generation composable with existing Redis and JWT support.
- Preserved the concurrent Python request DTO typing fix already present on this branch.
- Updated CLI help, interactive prompts, README, and docs for Rust Postgres support.

## Evidence

- Rebased #54 onto current `origin/feature/service-extension-capabilities`, which already includes #53.
- `make check` on #54 branch: Ruff passed, mypy passed on 36 source files, `249 passed in 2.20s`.
- Local merge-order verification: merged #54, then #56 into a throwaway branch from `origin/feature/service-extension-capabilities`; both merges completed without conflicts.
- `make check` on the combined verification branch: Ruff passed, mypy passed on 36 source files, `250 passed in 2.18s`.