### PR TITLE
[codex] Add JWT support for Rust services

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ poetry run kickstart create mono product-stack
 - Preferred stack: Rust, TypeScript, Python, SQL, and C++.
 - Go is supported as a tolerated service target; Python and Rust are the first-class library/CLI targets.
 - Service execution models: containers by default, Cloudflare Workers when requested.
-- Implemented service extensions are intentionally narrow: Python/FastAPI container services support Postgres, Redis, and JWT; Rust container services support Redis; TypeScript container services support Postgres.
+- Implemented service extensions are intentionally narrow: Python/FastAPI container services support Postgres, Redis, and JWT; Rust container services support Redis and JWT; TypeScript container services support Postgres.
 - System provider targets: `multi`, `aws`, `gcp`, `cloudflare`, or `none`.
 - System platform profiles: `kubernetes`, `cloudflare-workers`, or `hybrid`.
 - Dockerfiles are image artifacts; Helm and Kustomize are Kubernetes artifact styles; Wrangler is the Cloudflare Worker artifact path.
@@ -53,7 +53,7 @@ poetry run kickstart create mono product-stack
 
 ```bash
 poetry run kickstart create service my-api --lang python --database postgres --cache redis --auth jwt
-poetry run kickstart create service api-rs --lang rust --cache redis
+poetry run kickstart create service api-rs --lang rust --cache redis --auth jwt
 poetry run kickstart create service api-ts --lang typescript --database postgres
 poetry run kickstart create service edge-rs --lang rust --runtime cloudflare-workers
 poetry run kickstart create frontend web

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -51,7 +51,7 @@ Do not infer unsupported options. Use existing registries and typed plans.
 Implemented service extensions are intentionally narrow. As of this contract:
 
 - Python/FastAPI container services support `postgres`, `redis`, and `jwt`.
-- Rust container services support `redis`.
+- Rust container services support `redis` and `jwt`.
 - TypeScript container services support `postgres`.
 
 Do not pass unsupported extension options and assume they were generated.

--- a/docs/human-guide.md
+++ b/docs/human-guide.md
@@ -36,7 +36,7 @@ Implemented service extensions:
 Support is intentionally narrow:
 
 - Python/FastAPI container services support Postgres, Redis, and JWT.
-- Rust container services support Redis.
+- Rust container services support Redis and JWT.
 - TypeScript container services support Postgres.
 
 Other language/runtime/framework combinations fail loudly until their templates are implemented.

--- a/docs/scaffold-contract.md
+++ b/docs/scaffold-contract.md
@@ -26,7 +26,7 @@ There is no separate root architecture document. `docs/architecture/` is the can
 - `capabilities`: optional generated capabilities with real code support, for example `service_extensions: { database: postgres, cache: redis, auth: jwt }`.
 - `knowledge_adapter`: external knowledge integration metadata, for example `none`, `obsidian`, `backstage`, or `both`.
 
-Implemented service extensions are intentionally narrow. Python/FastAPI container services support Postgres, Redis, and JWT. Rust container services support Redis. TypeScript container services support Postgres. Unsupported combinations fail instead of generating a partial or silent scaffold.
+Implemented service extensions are intentionally narrow. Python/FastAPI container services support Postgres, Redis, and JWT. Rust container services support Redis and JWT. TypeScript container services support Postgres. Unsupported combinations fail instead of generating a partial or silent scaffold.
 
 Systems contain other project kinds and are currently generated through the `mono` command with `project.repo_layout: monorepo`.
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -155,7 +155,7 @@ def create(
     auth: Optional[str] = typer.Option(
         None,
         "--auth",
-        help="Authentication extension (implemented: jwt for Python/FastAPI services)",
+        help="Authentication extension (implemented: jwt for Python/FastAPI and Rust container services)",
     ),
     framework: Optional[str] = typer.Option(
         None,

--- a/src/cli/prompts.py
+++ b/src/cli/prompts.py
@@ -96,6 +96,17 @@ def prompt_for_missing_args(
             if database == "none":
                 database = None
 
+        if lang == "rust":
+            if cache is None:
+                cache = prompt.ask("Cache extension", choices=["none", "redis"], default="none")
+                if cache == "none":
+                    cache = None
+
+            if auth is None:
+                auth = prompt.ask("Authentication extension", choices=["none", "jwt"], default="none")
+                if auth == "none":
+                    auth = None
+
     assert project_type is not None, "project_type should be set by now"
     assert name is not None, "name should be set by now"
 

--- a/src/generator/language_setup.py
+++ b/src/generator/language_setup.py
@@ -15,6 +15,7 @@ class ContentFile:
 
 RUST_MODULE_CONTENT = "// Module definitions\n"
 RUST_CLIENTS_MODULE_CONTENT = "pub mod cache;\n"
+RUST_HANDLER_MODULE_CONTENT = "pub mod auth;\n"
 
 RUST_MAIN_CONTENT = """use actix_web::{App, HttpResponse, HttpServer, web};
 
@@ -31,10 +32,6 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 """
-
-RUST_MAIN_WITH_CLIENTS_CONTENT = f"""mod clients;
-
-{RUST_MAIN_CONTENT}"""
 
 CPP_ROUTES_HEADER_CONTENT = """#pragma once
 
@@ -92,10 +89,22 @@ TYPESCRIPT_POSTGRES_ENV_EXAMPLE_CONTENT = (
 )
 
 
-def rust_service_content_files(*, include_redis_cache: bool = False) -> tuple[ContentFile, ...]:
+def rust_service_content_files(
+    *,
+    include_redis_cache: bool = False,
+    include_jwt_auth: bool = False,
+) -> tuple[ContentFile, ...]:
     """Return direct content files for Rust services."""
-    main_content = RUST_MAIN_WITH_CLIENTS_CONTENT if include_redis_cache else RUST_MAIN_CONTENT
-    files = (
+    module_lines = []
+    if include_redis_cache:
+        module_lines.append("mod clients;")
+    if include_jwt_auth:
+        module_lines.append("mod handler;")
+    main_content = RUST_MAIN_CONTENT
+    if module_lines:
+        main_content = "\n".join(module_lines) + f"\n\n{RUST_MAIN_CONTENT}"
+
+    files: tuple[ContentFile, ...] = (
         ContentFile("src/api/mod.rs", RUST_MODULE_CONTENT),
         ContentFile("src/model/mod.rs", RUST_MODULE_CONTENT),
         ContentFile("tests/api/mod.rs", RUST_MODULE_CONTENT),
@@ -103,7 +112,9 @@ def rust_service_content_files(*, include_redis_cache: bool = False) -> tuple[Co
         ContentFile("src/main.rs", main_content),
     )
     if include_redis_cache:
-        return (*files, ContentFile("src/clients/mod.rs", RUST_CLIENTS_MODULE_CONTENT))
+        files = (*files, ContentFile("src/clients/mod.rs", RUST_CLIENTS_MODULE_CONTENT))
+    if include_jwt_auth:
+        files = (*files, ContentFile("src/handler/mod.rs", RUST_HANDLER_MODULE_CONTENT))
     return files
 
 

--- a/src/generator/service.py
+++ b/src/generator/service.py
@@ -369,16 +369,32 @@ class ServiceGenerator(BaseGenerator):
         - Proper crate structure
         """
         include_redis_cache = self.cache == "redis"
-        self._write_content_files(rust_service_content_files(include_redis_cache=include_redis_cache))
+        include_jwt_auth = self.auth == "jwt"
+        self._write_content_files(
+            rust_service_content_files(
+                include_redis_cache=include_redis_cache,
+                include_jwt_auth=include_jwt_auth,
+            )
+        )
         if include_redis_cache:
             self.write_template("src/clients/cache.rs", "rust/extensions/cache/redis.rs.tpl")
-            self.write_content(
-                ".env.example",
-                "EXAMPLE_ENV_VAR=value\nREDIS_URL=redis://127.0.0.1:6379/0\n",
-            )
-            self.write_template("Cargo.toml", "rust/Cargo.toml.tpl", cache="redis")
-            return
-        self.write_template("Cargo.toml", "rust/Cargo.toml.tpl")
+        if include_jwt_auth:
+            self.write_template("src/handler/auth.rs", "rust/extensions/auth/jwt.rs.tpl")
+
+        if include_redis_cache or include_jwt_auth:
+            env_content = "EXAMPLE_ENV_VAR=value\n"
+            if include_redis_cache:
+                env_content += "REDIS_URL=redis://127.0.0.1:6379/0\n"
+            if include_jwt_auth:
+                env_content += f"JWT_SECRET=change-me-change-me\nJWT_ISSUER={self.name}\n"
+            self.write_content(".env.example", env_content)
+
+        cargo_vars = {}
+        if include_redis_cache:
+            cargo_vars["cache"] = "redis"
+        if include_jwt_auth:
+            cargo_vars["auth"] = "jwt"
+        self.write_template("Cargo.toml", "rust/Cargo.toml.tpl", **cargo_vars)
 
     def _create_cpp_structure(self) -> None:
         """Create C++-specific project structure.

--- a/src/generator/service_capabilities.py
+++ b/src/generator/service_capabilities.py
@@ -39,6 +39,7 @@ _SERVICE_EXTENSION_SUPPORT: dict[tuple[str, str, str], ServiceExtensionSupport] 
     ),
     ("rust", "container", "default"): ServiceExtensionSupport(
         caches=IMPLEMENTED_CACHE_EXTENSIONS,
+        auth=IMPLEMENTED_AUTH_EXTENSIONS,
     ),
     ("typescript", "container", "default"): ServiceExtensionSupport(
         databases=IMPLEMENTED_DATABASE_EXTENSIONS,

--- a/src/templates/rust/Cargo.toml.tpl
+++ b/src/templates/rust/Cargo.toml.tpl
@@ -8,3 +8,7 @@ actix-web = "4"
 {% if cache == "redis" %}
 redis = { version = "1.2", features = ["tokio-comp"] }
 {% endif %}
+{% if auth == "jwt" %}
+jsonwebtoken = "9"
+serde = { version = "1", features = ["derive"] }
+{% endif %}

--- a/src/templates/rust/README.md.tpl
+++ b/src/templates/rust/README.md.tpl
@@ -24,6 +24,7 @@ make lint
 src/
 ├── api/          # API endpoints and routes
 ├── clients/      # Optional generated service clients
+├── handler/      # Optional generated auth helpers
 └── model/        # Data models and structures
 tests/
 ├── api/          # API tests

--- a/src/templates/rust/extensions/auth/jwt.rs.tpl
+++ b/src/templates/rust/extensions/auth/jwt.rs.tpl
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+
+use jsonwebtoken::{
+    Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode, errors::Error,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String,
+    pub exp: usize,
+    pub iss: String,
+}
+
+pub fn create_token(
+    subject: &str,
+    secret: &str,
+    issuer: &str,
+    expires_at: usize,
+) -> Result<String, Error> {
+    let claims = Claims {
+        sub: subject.to_string(),
+        exp: expires_at,
+        iss: issuer.to_string(),
+    };
+
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+}
+
+pub fn verify_token(token: &str, secret: &str, issuer: &str) -> Result<Claims, Error> {
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_issuer(&[issuer]);
+
+    let token_data = decode::<Claims>(
+        token,
+        &DecodingKey::from_secret(secret.as_bytes()),
+        &validation,
+    )?;
+    Ok(token_data.claims)
+}

--- a/tests/integration/test_project_creation.py
+++ b/tests/integration/test_project_creation.py
@@ -223,6 +223,30 @@ class TestServiceCreation:
         assert "redis = " in (project_path / "Cargo.toml").read_text()
         assert "REDIS_URL=redis://127.0.0.1:6379/0" in (project_path / ".env.example").read_text()
 
+    def test_rust_service_jwt_auth_extension(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
+        """Test Rust service generation with JWT auth support."""
+        service_name = "test-rust-jwt-service"
+
+        generator = ServiceGenerator(
+            name=service_name,
+            lang="rust",
+            gh=False,
+            config=mock_config,
+            root=str(temp_project_dir),
+            auth="jwt",
+        )
+        generator.create()
+
+        project_path = temp_project_dir / service_name
+        manifest = json.loads((project_path / ".kickstart/scaffold.json").read_text())
+
+        assert manifest["capabilities"] == {"service_extensions": {"auth": "jwt"}}
+        assert (project_path / "src/handler/mod.rs").read_text() == "pub mod auth;\n"
+        assert (project_path / "src/handler/auth.rs").exists()
+        assert "mod handler;" in (project_path / "src/main.rs").read_text()
+        assert "jsonwebtoken = " in (project_path / "Cargo.toml").read_text()
+        assert "JWT_SECRET=change-me-change-me" in (project_path / ".env.example").read_text()
+
     def test_typescript_service_postgres_database_extension(self, temp_project_dir: Path, mock_config: Dict[str, Any]):
         """Test TypeScript service generation with Postgres database support."""
         service_name = "test-typescript-postgres-service"

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -224,7 +224,7 @@ def test_create_monorepo_with_runtime(mock_load_config, mock_create_monorepo, ru
 def test_create_interactive_service(mock_prompt, mock_confirm, mock_load_config, mock_create_service, runner, mock_config):
     """Test creating a service interactively."""
     mock_load_config.return_value = mock_config
-    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "rust"]
+    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "rust", "none", "none"]
     mock_confirm.ask.side_effect = [True, True]  # gh=True, helm=True
     
     result = runner.invoke(app, ["create"])
@@ -232,6 +232,31 @@ def test_create_interactive_service(mock_prompt, mock_confirm, mock_load_config,
     assert result.exit_code == 0
     mock_create_service.assert_called_once_with(
         "my-service", "rust", True, mock_config, helm=True, root="/tmp"
+    )
+
+
+@patch('src.cli.main.create_service')
+@patch('src.cli.main.load_config')
+@patch('src.cli.main.Confirm')
+@patch('src.cli.main.Prompt')
+def test_create_interactive_rust_service_can_select_jwt(
+    mock_prompt,
+    mock_confirm,
+    mock_load_config,
+    mock_create_service,
+    runner,
+    mock_config,
+):
+    """Test selecting JWT for a Rust service interactively."""
+    mock_load_config.return_value = mock_config
+    mock_prompt.ask.side_effect = ["service", "my-service", "/tmp", "rust", "none", "jwt"]
+    mock_confirm.ask.side_effect = [False, False]
+
+    result = runner.invoke(app, ["create"])
+
+    assert result.exit_code == 0
+    mock_create_service.assert_called_once_with(
+        "my-service", "rust", False, mock_config, helm=False, root="/tmp", auth="jwt"
     )
 
 

--- a/tests/unit/generator/test_service.py
+++ b/tests/unit/generator/test_service.py
@@ -150,7 +150,6 @@ def test_create_rejects_unsupported_typescript_service_auth_extension():
     ("option", "kwargs"),
     [
         ("database", {"database": "postgres"}),
-        ("auth", {"auth": "jwt"}),
     ],
 )
 def test_create_rejects_unsupported_rust_service_extension_categories(option, kwargs):
@@ -295,6 +294,41 @@ def test_create_rust_structure_with_redis_cache(mock_write_content, mock_write_t
     )
     mock_write_template.assert_any_call("src/clients/cache.rs", "rust/extensions/cache/redis.rs.tpl")
     mock_write_template.assert_any_call("Cargo.toml", "rust/Cargo.toml.tpl", cache="redis")
+
+
+@patch.object(ServiceGenerator, 'write_template')
+@patch.object(ServiceGenerator, 'write_content')
+def test_create_rust_structure_with_jwt_auth(mock_write_content, mock_write_template, service_generator):
+    generator = ServiceGenerator("test-service", "rust", False, {}, auth="jwt")
+    generator._create_rust_structure()
+
+    mock_write_content.assert_any_call("src/handler/mod.rs", "pub mod auth;\n")
+    mock_write_content.assert_any_call(
+        ".env.example",
+        "EXAMPLE_ENV_VAR=value\nJWT_SECRET=change-me-change-me\nJWT_ISSUER=test-service\n",
+    )
+    mock_write_template.assert_any_call("src/handler/auth.rs", "rust/extensions/auth/jwt.rs.tpl")
+    mock_write_template.assert_any_call("Cargo.toml", "rust/Cargo.toml.tpl", auth="jwt")
+
+
+@patch.object(ServiceGenerator, 'write_template')
+@patch.object(ServiceGenerator, 'write_content')
+def test_create_rust_structure_with_redis_and_jwt(mock_write_content, mock_write_template, service_generator):
+    generator = ServiceGenerator("test-service", "rust", False, {}, cache="redis", auth="jwt")
+    generator._create_rust_structure()
+
+    mock_write_content.assert_any_call("src/clients/mod.rs", "pub mod cache;\n")
+    mock_write_content.assert_any_call("src/handler/mod.rs", "pub mod auth;\n")
+    mock_write_content.assert_any_call(
+        ".env.example",
+        "EXAMPLE_ENV_VAR=value\n"
+        "REDIS_URL=redis://127.0.0.1:6379/0\n"
+        "JWT_SECRET=change-me-change-me\n"
+        "JWT_ISSUER=test-service\n",
+    )
+    mock_write_template.assert_any_call("src/clients/cache.rs", "rust/extensions/cache/redis.rs.tpl")
+    mock_write_template.assert_any_call("src/handler/auth.rs", "rust/extensions/auth/jwt.rs.tpl")
+    mock_write_template.assert_any_call("Cargo.toml", "rust/Cargo.toml.tpl", cache="redis", auth="jwt")
 
 
 @patch.object(ServiceGenerator, 'write_content')

--- a/tests/unit/generator/test_service_capabilities.py
+++ b/tests/unit/generator/test_service_capabilities.py
@@ -36,6 +36,21 @@ def test_rust_container_accepts_redis_cache_extension() -> None:
     assert selection.auth is None
 
 
+def test_rust_container_accepts_jwt_auth_extension() -> None:
+    selection = validate_service_extensions(
+        language="rust",
+        runtime="container",
+        framework=None,
+        database=None,
+        cache=None,
+        auth="jwt",
+    )
+
+    assert selection.database is None
+    assert selection.cache is None
+    assert selection.auth == "jwt"
+
+
 def test_typescript_container_accepts_postgres_database_extension() -> None:
     selection = validate_service_extensions(
         language="typescript",
@@ -79,7 +94,6 @@ def test_typescript_services_reject_jwt_until_templates_exist() -> None:
     ("category", "kwargs"),
     [
         ("database", {"database": "postgres", "cache": None, "auth": None}),
-        ("auth", {"database": None, "cache": None, "auth": "jwt"}),
     ],
 )
 def test_rust_container_rejects_unimplemented_extension_categories(


### PR DESCRIPTION
Closes #40.

Stacked on #48 / `feature/service-extension-capabilities`.

## What changed

- Added Rust/container `--auth jwt` to the service extension capability matrix.
- Generated typed JWT helpers at `src/handler/auth.rs` using `jsonwebtoken` and `serde`.
- Added `JWT_SECRET` and `JWT_ISSUER` to generated `.env.example`.
- Rendered `jsonwebtoken` and `serde` only when `--auth jwt` is selected.
- Refactored Rust extension generation so supported Redis and JWT extensions can compose in the same scaffold.
- Updated CLI help, interactive prompts, README, and docs to describe Rust JWT support.
- Kept unsupported combinations loud: Rust Postgres and TypeScript JWT still fail on this branch until their feature branches land.

## Evidence

- `make check` in kickstart: Ruff passed, mypy passed on 36 source files, `249 passed in 2.17s`.
- Generated sample: `poetry run kickstart create service rust-jwt-api --root /private/tmp/kickstart-rust-jwt-evidence-01 --lang rust --auth jwt`.
- Generated sample files included `src/handler/auth.rs`, `src/handler/mod.rs`, `JWT_SECRET`, `JWT_ISSUER`, `jsonwebtoken`, `serde`, and `.kickstart/scaffold.json` with `capabilities.service_extensions.auth = jwt`.
- Generated Rust service `make check`: `cargo fmt --all -- --check`, `cargo fetch`, `cargo check`, and `cargo test` all passed.
- Negative checks:
  - `poetry run kickstart create service rust-postgres-api --root /private/tmp/kickstart-rust-jwt-evidence-01 --lang rust --database postgres` failed with unsupported Rust Postgres message.
  - `poetry run kickstart create service ts-jwt-api --root /private/tmp/kickstart-rust-jwt-evidence-01 --lang typescript --auth jwt` failed with unsupported TypeScript JWT message.