### PR TITLE
Shrink release binary matrix to py3.14 only on supported runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,37 +97,10 @@ jobs:
         include:
           - runner: ubuntu-24.04
             platform: linux-x64
-            python-version: "3.12"
-          - runner: ubuntu-24.04
-            platform: linux-x64
-            python-version: "3.13"
-          - runner: ubuntu-24.04
-            platform: linux-x64
             python-version: "3.14"
           - runner: ubuntu-24.04-arm
             platform: linux-arm64
-            python-version: "3.12"
-          - runner: ubuntu-24.04-arm
-            platform: linux-arm64
-            python-version: "3.13"
-          - runner: ubuntu-24.04-arm
-            platform: linux-arm64
             python-version: "3.14"
-          - runner: macos-15-intel
-            platform: macos-x64
-            python-version: "3.12"
-          - runner: macos-15-intel
-            platform: macos-x64
-            python-version: "3.13"
-          - runner: macos-15-intel
-            platform: macos-x64
-            python-version: "3.14"
-          - runner: macos-15
-            platform: macos-arm64
-            python-version: "3.12"
-          - runner: macos-15
-            platform: macos-arm64
-            python-version: "3.13"
           - runner: macos-15
             platform: macos-arm64
             python-version: "3.14"


### PR DESCRIPTION
## Summary
- Removes `macos-x64` from the release binary matrix. The `macos-15-intel` runner label is no longer scheduling on x64 hardware in this org, so PyInstaller fails with `IncompatibleBinaryArchError` (arm64 wheels for an x86_64 target). x64 macOS users can install via PyPI.
- Removes Python 3.12 and 3.13 from the release binary matrix. Ships py3.14 binaries only, which matches `install.sh`'s `KICKSTART_PYTHON_MINOR=3.14` default. Users on older Pythons can `pip install kickstart` from PyPI.
- Binary matrix shrinks from 12 jobs to **3** (linux-x64, linux-arm64, macos-arm64 — each at py3.14).

## Context
The `v0.4.1` tag was pushed earlier and the release workflow failed: all three macos-x64 jobs errored with `IncompatibleBinaryArchError: ... is incompatible with target arch x86_64 (has arch: arm64)`. Because any binary-build failure blocks `release: needs: [package, binary]`, no GitHub Release was published — `gh release view v0.4.1` returns "release not found".

This PR unblocks the release pipeline. After it merges:
1. The `v0.4.1` tag will be rewritten to point at the new master HEAD.
2. The release workflow will re-fire and (intended) publish a 9-asset release: 3 `kickstart-<plat>-py3.14.tar.gz` archives × 2 (binary + `.sha256`), plus `.whl`, sdist, and `install.sh`.
3. The README's `curl … install.sh | bash` one-liner will work for end users.

## Out of scope (deferred to follow-ups)
- `src/__init__.py:__version__` is still `"0.4.0"` — PR #65 bumped `pyproject.toml` but missed the runtime version constant. So `kickstart version` will print `v0.4.0` even after this release publishes. Pure source-code fix; tracked separately.
- `ci/release_policy.py` should be tightened to require `pyproject.toml` ↔ `src/__init__.py` agreement. Bundled with the version-bump follow-up so the gate doesn't block this release.
- Deprecated Node-20 actions (`actions/cache@v4`, `actions/checkout@v4`, `actions/setup-python@v5`) — separate PR before 2026-06-16.
- `.github/workflows/ci.yml` is untouched. CI still runs the test suite against py3.12/3.13/3.14 if it did before.

## Test plan
- [x] `yamllint` clean (workflow file is valid YAML).
- [ ] After merge, rewrite `v0.4.1` tag onto new master HEAD and observe the release workflow complete green.
- [ ] Confirm `gh release view v0.4.1` lists the expected 9 assets.
- [ ] Run the README install one-liner on macOS arm64 and confirm `kickstart` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)