### PR TITLE
Update example paths from /private/tmp to /tmp

### DIFF
--- a/.agents/skills/kickstart/SKILL.md
+++ b/.agents/skills/kickstart/SKILL.md
@@ -16,9 +16,9 @@ Confirm `kickstart` exists. Read `kickstart create --help` only when syntax is u
 Common patterns:
 
 ```bash
-kickstart create cli ops-tool --lang rust --root /private/tmp/kickstart-output
-kickstart create service my-api --lang python --root /private/tmp/kickstart-output
-kickstart create system platform --cloud aws --runtime kubernetes --knowledge none --root /private/tmp/kickstart-output
+kickstart create cli ops-tool --lang rust --root /tmp/kickstart-output
+kickstart create service my-api --lang python --root /tmp/kickstart-output
+kickstart create system platform --cloud aws --runtime kubernetes --knowledge none --root /tmp/kickstart-output
 ```
 
 Use `create frontend NAME --root ...` for frontends and `create lib NAME --lang python|rust --root ...` for libraries.

--- a/README.md
+++ b/README.md
@@ -163,4 +163,4 @@ make binary
 
 kickstart supports Python `>=3.12,<3.15`. CI tests Python 3.12, 3.13, and 3.14 on Linux and macOS. Release builds attach Linux/macOS x64 and arm64 binary archives (`kickstart-<platform>-py<minor>.tar.gz`) for each supported Python minor.
 
-Current local eval evidence is tracked in [Local Evals](docs/evals.md). Reports are generated under `/private/tmp` or another scratch path and are not committed.
+Current local eval evidence is tracked in [Local Evals](docs/evals.md). Reports are generated under `/tmp` or another scratch path and are not committed.


### PR DESCRIPTION
## Primary changes

- Normalize macOS-specific `/private/tmp` scratch paths to `/tmp` in the `kickstart` skill examples and the README local-eval note, matching the convention already used in `docs/evals.md`.

## Reviewer walkthrough

- `.agents/skills/kickstart/SKILL.md` — `--root` in the three example commands.
- `README.md` — the local-eval reports note.

## Correctness and invariants

- Docs/skill only; no code change. `/tmp` is canonical on both Linux and macOS, so the examples now work in Linux sandboxes; `/private/tmp` was macOS-only.

## Testing and QA

- `grep` confirms no `/private/tmp` remains in tracked docs/skills; `docs/evals.md` already used `/tmp`.

## Risk / Rollout

- Documentation only, no runtime impact. Surfaced by the docs/README/skills consistency audit (no dedicated issue). Part of the 0.4.3 line.