### PR TITLE
Bootstrap the Claude Code on the web sandbox with a SessionStart hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# SessionStart hook for Claude Code on the web.
+#
+# Bootstraps the kickstart toolchain in a fresh remote sandbox so that
+# `make check` and the website checks work immediately, instead of every
+# session re-discovering that the default `python3` is too old for the
+# `>=3.12` floor and re-running poetry/bun installs by hand.
+#
+# Synchronous, idempotent, non-interactive. Verbose install output goes to
+# stderr (visible in logs) so the agent's context stays clean; only a short
+# readiness summary is written to stdout.
+set -euo pipefail
+
+# Only bootstrap in the remote (Claude Code on the web) sandbox. Local
+# sessions manage their own environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+
+log() { printf 'session-start: %s\n' "$*" >&2; }
+
+# kickstart requires Python >=3.12,<3.15 (pyproject [project].requires-python).
+# The sandbox default may be older, so pin Poetry's virtualenv to the newest
+# supported interpreter that is actually present.
+for py in python3.14 python3.13 python3.12; do
+  if command -v "$py" >/dev/null 2>&1; then
+    log "using $py for the Poetry environment"
+    poetry env use "$py" >&2
+    break
+  fi
+done
+
+# Python dependencies. `install` (not a frozen/sync variant) lets the cached
+# container state be reused across sessions.
+log "installing Python dependencies with Poetry"
+poetry install --no-interaction >&2
+
+# Website dependencies (TypeScript Cloudflare Worker under website/).
+if command -v bun >/dev/null 2>&1 && [ -f website/package.json ]; then
+  log "installing website dependencies with Bun"
+  (cd website && bun install) >&2
+fi
+
+echo "kickstart sandbox ready: 'make check' and 'cd website && bun run check' will work."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Primary changes

- Add a SessionStart hook (`.claude/hooks/session-start.sh`, registered in `.claude/settings.json`) that bootstraps the Claude Code on the web sandbox: pin Poetry to the newest supported interpreter, install Python and website dependencies.

## Reviewer walkthrough

- `.claude/hooks/session-start.sh` — `CLAUDE_CODE_REMOTE` guard, interpreter pin, `poetry install`, `bun install`, stderr redirection.
- `.claude/settings.json` — SessionStart registration.

## Correctness and invariants

- Claude Code-specific by nature (lifecycle event, `CLAUDE_*` env, settings.json registration) and hooks have no cross-vendor standard, so it lives under `.claude/` rather than the neutral `.agents/`. Remote-only (guarded), synchronous, idempotent, non-interactive; verbose install output goes to stderr. No effect on local sessions or generated projects.

## Testing and QA

- Runs green (`CLAUDE_CODE_REMOTE=true … .claude/hooks/session-start.sh` → "kickstart sandbox ready…") and fired live on session resume. `ruff check src/cli/main.py` clean; `pytest tests/unit/ci/test_release_policy.py` passed.

## Risk / Rollout

- Takes effect for web sessions once merged to `master`. Synchronous trade-off: guaranteed readiness vs slightly slower startup (switchable to async). Part of the 0.4.3 line.

Resolves ENG-135