### PR TITLE
Tiered eval runner and scaffold-weight regression baselines (ENG-106)

### DIFF
--- a/.agents/skills/scaffold-evals/SKILL.md
+++ b/.agents/skills/scaffold-evals/SKILL.md
@@ -5,6 +5,20 @@ description: Run kickstart's scaffold-shape and generated-make-test evals after 
 
 # Scaffold Evals
 
+## Hot Path
+
+One entrypoint, tiered:
+
+```bash
+PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier pr    # or smoke / full
+```
+
+After deliberate template weight changes, re-baseline:
+
+```bash
+PYTHONPATH=$(pwd) poetry run python scripts/token_savings_eval.py --update-baselines
+```
+
 ## Use When
 
 Use this skill after changing generators, layouts, template plans, language

--- a/docs/decisions/headroom-benchmark-learnings.md
+++ b/docs/decisions/headroom-benchmark-learnings.md
@@ -1,0 +1,83 @@
+# Headroom Benchmark Learnings
+
+Date: 2026-06-12
+
+Source studied: https://github.com/chopratejas/headroom — a context-compression
+layer for AI agents (60–95% token reduction claims). Its `/benchmarks`
+directory and published methodology carry several practices worth comparing
+against kickstart's eval suite (`docs/evals.md`).
+
+## What headroom does that we should notice
+
+1. **Paired quality + efficiency metrics.** Headroom never reports
+   compression alone; every headline pairs compression % with accuracy
+   preserved on standard tasks (GSM8K 0.870 baseline maintained, SQuAD v2
+   97% accuracy at 19% compression, BFCL 97% at 32%). The optimization is
+   only claimed valid while the outcome metric holds.
+2. **A central runner with tiers.** `python -m headroom.evals suite
+   --tier 1` — one entrypoint, tier 1 cheap enough to run often, deeper
+   tiers for thorough validation.
+3. **Adversarial and worst-case suites as committed code.**
+   `adversarial_ccr_tests.py`, `headroom_worst_case_benchmark.py` — attack
+   coverage is a repeatable artifact, not a one-off review.
+4. **Regression benchmarks.** `ccr_regression_benchmark.py` pins prior
+   results so optimization wins cannot silently erode.
+5. **Scenario fixtures separated from runner code** (`scenarios/`), with a
+   single `run_benchmarks.py` harness.
+6. **Real-workload case studies beside synthetic suites** (code search 92%,
+   SRE debugging 92%, issue triage 73%) — synthetic benchmarks prove
+   mechanism, workload studies prove relevance.
+7. **Headline numbers ship with the reproduce command** in the README/docs.
+
+## Where kickstart already stands
+
+| Headroom practice | kickstart today |
+| --- | --- |
+| Paired quality+efficiency | Split across two evals: token savings (efficiency) and bootstrap eval (quality = own `make check` green). Not yet one report. |
+| Tiered central runner | Implicit: CI runs 4 bootstrap cases, weekly runs the full matrix, each eval is its own script with its own flags. |
+| Codified adversarial suite | Partially: the trust properties found by adversarial review are pinned as unit/integration tests; the 20-run cold-start evaluation itself was manual. |
+| Regression baselines | None. Nothing stops generated output from silently bloating (or losing files) between releases — and token weight is a core promise. |
+| Scenario fixtures | Cases are typed tuples inline in each eval — fine at current scale. |
+| Real-workload studies | The 20-run cold-start evaluation (documented in CHANGELOG/PR #68) is exactly this, but it is methodology-by-anecdote, not a committed artifact. |
+| Reproduce command with numbers | `docs/evals.md` does this. |
+
+## Adopted in this branch
+
+1. **Scaffold weight regression baselines** (headroom practices 1 + 4).
+   `scripts/token_savings_eval.py` gains `--check-baselines` /
+   `--update-baselines` against a committed
+   `tests/fixtures/scaffold-weight-baselines.json` (per-case file count
+   exact, content bytes within ±10%). This is the regression benchmark for
+   kickstart's efficiency promise: template changes that bloat generated
+   output or drop files now fail an eval instead of shipping silently.
+   Deterministic by construction — no flaky timing, no model in the loop.
+2. **Unified tiered eval runner** (practice 2).
+   `scripts/run_evals.py --tier {smoke,pr,full}`: one entrypoint that
+   orchestrates the existing evals and prints a single summary table.
+   `smoke` = headline bootstrap case; `pr` = the four CI bootstrap cases +
+   weight baselines; `full` = whole bootstrap matrix + token eval with
+   baselines + determinism and website-examples test suites.
+
+## Considered and deferred (with reasons)
+
+- **Codifying the cold-start agent evaluation as a benchmark.** Headroom's
+  agent benchmarks have an LLM in the loop; ours would too. That makes the
+  numbers non-deterministic and expensive — useful as a release-time study
+  (as run for v0.4.2), wrong as a committed pass/fail gate. Keep it a
+  documented methodology, re-run per release line.
+- **Latency benchmarks.** Generation is ~1s and `make check` seconds are
+  already reported per bootstrap case; budgets on shared-runner wall time
+  would mostly measure runner noise.
+- **Separate `benchmarks/` tree.** Headroom splits benchmarks from tests;
+  kickstart's evals already live in `scripts/` with unit tests in
+  `tests/unit/scripts/`. One home is enough at this scale.
+- **Worst-case suite.** The scaffold matrix eval (500 projects) already
+  plays this role for generation; the adversarial CLI cases are pinned as
+  tests.
+
+## Follow-up candidates (not in this branch)
+
+- Fold the paired headline into one published table: per scaffold, tokens
+  saved *and* its own-check status from the same run.
+- A committed scenario file for the cold-start evaluation prompts, so the
+  per-release study stays comparable across releases.

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -1,5 +1,17 @@
 # Local Evals
 
+One entrypoint runs the suite by tier (see
+`docs/decisions/headroom-benchmark-learnings.md` for where this design
+comes from):
+
+```bash
+PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier smoke   # headline bootstrap case
+PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier pr      # what CI gates per PR + weight baselines
+PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier full    # full matrix + tokens + determinism + website
+```
+
+Individual evals below remain directly runnable for iteration.
+
 kickstart has two useful local eval layers:
 
 - Scaffold shape: generate many supported project combinations and verify the generator commands succeed.

--- a/scripts/run_evals.py
+++ b/scripts/run_evals.py
@@ -1,0 +1,154 @@
+"""One entrypoint for kickstart's eval suite, in tiers.
+
+Modeled on the tiered-suite practice from headroom's benchmark harness
+(`docs/decisions/headroom-benchmark-learnings.md`): a single command runs a
+named tier and prints one summary table, so "did the evals pass" has exactly
+one answer per tier.
+
+Tiers:
+
+- ``smoke``: the headline bootstrap case. Seconds with a warm cache.
+- ``pr``: what CI gates per pull request — the four fast bootstrap cases
+  plus the scaffold-weight baseline check.
+- ``full``: the whole bootstrap matrix, token savings with baselines, and
+  the determinism + website-examples test suites. What the weekly run and
+  release validation use.
+
+Usage::
+
+    PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier pr
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+
+class UnknownTierError(Exception):
+    """Raised when a requested tier does not exist."""
+
+    def __init__(self, tier: str, known: tuple[str, ...]) -> None:
+        super().__init__(f"unknown tier '{tier}'; known tiers: {', '.join(known)}")
+
+
+@dataclass(frozen=True)
+class EvalStep:
+    """One command within a tier."""
+
+    name: str
+    args: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Outcome of one executed step."""
+
+    step: EvalStep
+    returncode: int
+    seconds: float
+    tail: str
+
+    @property
+    def passed(self) -> bool:
+        return self.returncode == 0
+
+
+_SCRATCH = Path(tempfile.gettempdir())
+_PYTHON = sys.executable
+
+_BOOTSTRAP_COMMON = (
+    _PYTHON,
+    "scripts/bootstrap_eval.py",
+    "--output-root",
+    str(_SCRATCH / "kickstart-run-evals-bootstrap"),
+    "--cache-root",
+    str(_SCRATCH / "kickstart-eval-cache"),
+    "--report",
+    str(_SCRATCH / "kickstart-run-evals-bootstrap.md"),
+)
+
+_PR_BOOTSTRAP_CASES = ("python-cli-kickstart-like", "python-service", "typescript-worker", "rust-cli")
+
+_TOKEN_BASELINES = (
+    _PYTHON,
+    "scripts/token_savings_eval.py",
+    "--check-baselines",
+    "--output-root",
+    str(_SCRATCH / "kickstart-run-evals-tokens"),
+    "--report",
+    str(_SCRATCH / "kickstart-run-evals-tokens.md"),
+)
+
+_PYTEST = (_PYTHON, "-m", "pytest", "-q")
+
+TIERS: dict[str, tuple[EvalStep, ...]] = {
+    "smoke": (
+        EvalStep("bootstrap (headline case)", (*_BOOTSTRAP_COMMON, "--cases", "python-cli-kickstart-like")),
+    ),
+    "pr": (
+        EvalStep("bootstrap (CI cases)", (*_BOOTSTRAP_COMMON, "--cases", *_PR_BOOTSTRAP_CASES)),
+        EvalStep("scaffold weight baselines", _TOKEN_BASELINES),
+    ),
+    "full": (
+        EvalStep("bootstrap (full matrix)", _BOOTSTRAP_COMMON),
+        EvalStep("scaffold weight baselines", _TOKEN_BASELINES),
+        EvalStep("determinism tests", (*_PYTEST, "tests/integration/test_scaffold_determinism.py")),
+        EvalStep("website examples tests", (*_PYTEST, "tests/integration/test_website_examples.py")),
+    ),
+}
+
+
+def tier_steps(tier: str) -> tuple[EvalStep, ...]:
+    """Resolve a tier name, failing loudly on unknown tiers."""
+    try:
+        return TIERS[tier]
+    except KeyError as error:
+        raise UnknownTierError(tier, tuple(TIERS)) from error
+
+
+def run_step(step: EvalStep, repo_root: Path) -> StepResult:
+    """Run one step, capturing its tail for the summary."""
+    started = time.monotonic()
+    completed = subprocess.run(step.args, cwd=repo_root, capture_output=True, text=True, check=False)
+    elapsed = time.monotonic() - started
+    tail = "\n".join((completed.stdout + completed.stderr).strip().splitlines()[-8:])
+    return StepResult(step=step, returncode=completed.returncode, seconds=elapsed, tail=tail)
+
+
+def render_summary(tier: str, results: tuple[StepResult, ...]) -> str:
+    """Render the single summary table for a tier run."""
+    lines = [
+        f"# kickstart evals — tier: {tier}",
+        "",
+        "| step | result | seconds |",
+        "| --- | --- | ---: |",
+    ]
+    for result in results:
+        lines.append(f"| {result.step.name} | {'pass' if result.passed else 'FAIL'} | {result.seconds:.1f} |")
+    lines.append("")
+    for result in results:
+        if not result.passed:
+            lines.extend([f"## FAIL: {result.step.name} (exit {result.returncode})", "", result.tail, ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Run an eval tier from the command line."""
+    parser = argparse.ArgumentParser(description="Run kickstart's eval suite by tier.")
+    parser.add_argument("--tier", choices=sorted(TIERS), default="smoke")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    results = tuple(run_step(step, repo_root) for step in tier_steps(args.tier))
+    print(render_summary(args.tier, results))
+    return 0 if all(result.passed for result in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/token_savings_eval.py
+++ b/scripts/token_savings_eval.py
@@ -262,6 +262,82 @@ def results_as_json(results: tuple[CaseResult, ...]) -> str:
     return json.dumps(payload, indent=2)
 
 
+# Scaffold weight regression baselines: file counts must match exactly
+# (file additions/removals are deliberate acts), content bytes may move
+# within this tolerance before the change must be acknowledged by
+# re-running with --update-baselines.
+BASELINE_BYTES_TOLERANCE = 0.10
+BASELINES_PATH = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "scaffold-weight-baselines.json"
+
+
+class BaselineError(Exception):
+    """Raised when committed scaffold-weight baselines cannot be used."""
+
+
+@dataclass(frozen=True)
+class BaselineDrift:
+    """One scaffold whose generated weight drifted from its baseline."""
+
+    slug: str
+    detail: str
+
+
+def baselines_payload(results: tuple[CaseResult, ...]) -> str:
+    """Render the committed baseline file content for the measured cases."""
+    payload = {
+        result.case.slug: {"files": result.file_count, "content_bytes": result.content_bytes}
+        for result in results
+    }
+    return json.dumps(payload, indent=2, sort_keys=True) + "\n"
+
+
+def compare_baselines(
+    results: tuple[CaseResult, ...],
+    baselines: dict[str, dict[str, int]],
+    *,
+    tolerance: float = BASELINE_BYTES_TOLERANCE,
+) -> tuple[BaselineDrift, ...]:
+    """Compare measured scaffold weight against committed baselines."""
+    drifts: list[BaselineDrift] = []
+    for result in results:
+        baseline = baselines.get(result.case.slug)
+        if baseline is None:
+            drifts.append(BaselineDrift(result.case.slug, "no committed baseline; run --update-baselines"))
+            continue
+
+        if result.file_count != baseline["files"]:
+            drifts.append(
+                BaselineDrift(
+                    result.case.slug,
+                    f"file count {result.file_count} != baseline {baseline['files']} "
+                    "(file additions/removals must be deliberate; re-baseline if so)",
+                )
+            )
+
+        allowed = baseline["content_bytes"] * tolerance
+        delta = result.content_bytes - baseline["content_bytes"]
+        if abs(delta) > allowed:
+            direction = "grew" if delta > 0 else "shrank"
+            drifts.append(
+                BaselineDrift(
+                    result.case.slug,
+                    f"content {direction} {abs(delta)} bytes ({delta / baseline['content_bytes']:+.1%}) "
+                    f"vs baseline {baseline['content_bytes']}; tolerance is ±{tolerance:.0%}",
+                )
+            )
+    return tuple(drifts)
+
+
+def load_baselines(path: Path) -> dict[str, dict[str, int]]:
+    """Load committed baselines, failing with a specific error when absent."""
+    if not path.is_file():
+        raise BaselineError(f"baseline file {path} is missing; run with --update-baselines first")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise BaselineError(f"baseline file {path} is not a JSON object")
+    return raw
+
+
 def main() -> int:
     """Run the token savings eval from the command line."""
     parser = argparse.ArgumentParser(description="Measure agent token savings per kickstart scaffold.")
@@ -269,6 +345,16 @@ def main() -> int:
     parser.add_argument("--output-root", type=Path, default=scratch / "kickstart-token-savings")
     parser.add_argument("--report", type=Path, default=scratch / "kickstart-token-savings.md")
     parser.add_argument("--json", action="store_true", help="Print machine-readable results to stdout")
+    parser.add_argument(
+        "--check-baselines",
+        action="store_true",
+        help="Fail when generated scaffold weight drifts from the committed baselines",
+    )
+    parser.add_argument(
+        "--update-baselines",
+        action="store_true",
+        help="Rewrite the committed scaffold-weight baselines from this run",
+    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parent.parent
@@ -283,6 +369,20 @@ def main() -> int:
     else:
         print(report)
     print(f"Report written to {args.report}", file=sys.stderr)
+
+    if args.update_baselines:
+        BASELINES_PATH.write_text(baselines_payload(results), encoding="utf-8")
+        print(f"Baselines written to {BASELINES_PATH}", file=sys.stderr)
+        return 0
+
+    if args.check_baselines:
+        drifts = compare_baselines(results, load_baselines(BASELINES_PATH))
+        for drift in drifts:
+            print(f"baseline drift: {drift.slug}: {drift.detail}", file=sys.stderr)
+        if drifts:
+            return 1
+        print("Scaffold weight matches committed baselines.", file=sys.stderr)
+
     return 0
 
 

--- a/tests/fixtures/scaffold-weight-baselines.json
+++ b/tests/fixtures/scaffold-weight-baselines.json
@@ -1,0 +1,22 @@
+{
+  "aws-kubernetes-system": {
+    "content_bytes": 23323,
+    "files": 41
+  },
+  "python-lib": {
+    "content_bytes": 6897,
+    "files": 13
+  },
+  "python-service-full": {
+    "content_bytes": 23632,
+    "files": 48
+  },
+  "rust-cli": {
+    "content_bytes": 9106,
+    "files": 24
+  },
+  "typescript-worker": {
+    "content_bytes": 10379,
+    "files": 19
+  }
+}

--- a/tests/unit/scripts/test_run_evals.py
+++ b/tests/unit/scripts/test_run_evals.py
@@ -1,0 +1,35 @@
+import pytest
+
+from scripts.run_evals import TIERS, EvalStep, StepResult, UnknownTierError, render_summary, tier_steps
+
+
+def test_every_tier_has_steps_and_smoke_is_smallest() -> None:
+    assert set(TIERS) == {"smoke", "pr", "full"}
+    assert all(steps for steps in TIERS.values())
+    assert len(TIERS["smoke"]) < len(TIERS["pr"]) < len(TIERS["full"])
+
+
+def test_tier_steps_rejects_unknown_tier() -> None:
+    with pytest.raises(UnknownTierError, match="unknown tier 'nope'"):
+        tier_steps("nope")
+
+
+def test_pr_tier_gates_weight_baselines() -> None:
+    names = [step.name for step in tier_steps("pr")]
+
+    assert "scaffold weight baselines" in names
+
+
+def test_render_summary_marks_failures_with_tail() -> None:
+    step = EvalStep("demo", ("true",))
+    results = (
+        StepResult(step=step, returncode=0, seconds=1.2, tail="ok"),
+        StepResult(step=step, returncode=1, seconds=0.4, tail="boom: detail"),
+    )
+
+    summary = render_summary("pr", results)
+
+    assert "| demo | pass | 1.2 |" in summary
+    assert "| demo | FAIL | 0.4 |" in summary
+    assert "## FAIL: demo (exit 1)" in summary
+    assert "boom: detail" in summary

--- a/tests/unit/scripts/test_token_savings_eval.py
+++ b/tests/unit/scripts/test_token_savings_eval.py
@@ -1,9 +1,17 @@
 from pathlib import Path
 
+import json
+
+import pytest
+
 from scripts.token_savings_eval import (
+    BaselineError,
     DEFAULT_CASES,
     CaseResult,
     ScaffoldCase,
+    baselines_payload,
+    compare_baselines,
+    load_baselines,
     estimate_tokens,
     is_text_file,
     measure_tree,
@@ -84,3 +92,55 @@ def test_render_report_lists_every_case_and_total() -> None:
     assert "| total |" in report
     assert "bytes per token" in report
     assert "upper bound" in report
+
+
+def make_result(slug: str, files: int, content_bytes: int) -> CaseResult:
+    return CaseResult(
+        case=ScaffoldCase(slug=slug, args=("create", "cli", slug)),
+        command_text=f"kickstart create cli {slug}",
+        file_count=files,
+        content_bytes=content_bytes,
+        app_code_bytes=content_bytes // 2,
+    )
+
+
+def test_compare_baselines_accepts_drift_within_tolerance() -> None:
+    results = (make_result("demo", files=10, content_bytes=10_500),)
+    baselines = {"demo": {"files": 10, "content_bytes": 10_000}}
+
+    assert compare_baselines(results, baselines, tolerance=0.10) == ()
+
+
+def test_compare_baselines_flags_bloat_and_file_changes() -> None:
+    results = (make_result("demo", files=11, content_bytes=12_000),)
+    baselines = {"demo": {"files": 10, "content_bytes": 10_000}}
+
+    drifts = compare_baselines(results, baselines, tolerance=0.10)
+
+    details = [drift.detail for drift in drifts]
+    assert any("file count 11 != baseline 10" in detail for detail in details)
+    assert any("grew 2000 bytes" in detail for detail in details)
+
+
+def test_compare_baselines_flags_shrinkage_and_missing_baseline() -> None:
+    results = (make_result("demo", files=10, content_bytes=8_000), make_result("new-case", files=5, content_bytes=1_000))
+    baselines = {"demo": {"files": 10, "content_bytes": 10_000}}
+
+    drifts = compare_baselines(results, baselines, tolerance=0.10)
+
+    details = {drift.slug: drift.detail for drift in drifts}
+    assert "shrank 2000 bytes" in details["demo"]
+    assert "no committed baseline" in details["new-case"]
+
+
+def test_baselines_payload_round_trips_through_compare() -> None:
+    results = (make_result("demo", files=10, content_bytes=10_000),)
+
+    baselines = json.loads(baselines_payload(results))
+
+    assert compare_baselines(results, baselines) == ()
+
+
+def test_load_baselines_requires_existing_file(tmp_path: Path) -> None:
+    with pytest.raises(BaselineError, match="missing; run with --update-baselines"):
+        load_baselines(tmp_path / "absent.json")


### PR DESCRIPTION
## Primary changes

- `scripts/run_evals.py --tier smoke|pr|full`: one entrypoint for the eval suite, a single summary table, non-zero exit on any failing step.
- Scaffold-weight regression baselines: `token_savings_eval.py --check-baselines` / `--update-baselines` against committed `tests/fixtures/scaffold-weight-baselines.json` (file count exact, content bytes ±10%).

## Reviewer walkthrough

- `scripts/run_evals.py` + `tests/unit/scripts/test_run_evals.py` — tiers and summary.
- `scripts/token_savings_eval.py` + `tests/unit/scripts/test_token_savings_eval.py` — baseline compare/update.
- `tests/fixtures/scaffold-weight-baselines.json` — committed baselines.
- `docs/decisions/headroom-benchmark-learnings.md`, `docs/evals.md`, `.agents/skills/scaffold-evals/SKILL.md`.

## Correctness and invariants

- Deterministic (no model/timing in the loop). Any file-count change or >±10% byte drift fails; deliberate changes re-baseline explicitly. Adopt/defer reasoning recorded in the decision doc.

## Testing and QA

- All three tiers green (smoke ~12s, pr ~86s, full ~78s). Guard demonstrated live on injected README-template bloat (`python-service-full +10.9%`, `python-lib +37.5%`, exit 1; clean after revert). `make check` green (444 passed); 9 new unit tests.

## Risk / Rollout

- Repo tooling only; no generated-output or CLI change. Deferred (open question): swap CI's per-PR bootstrap step to `run_evals.py --tier pr` after it soaks. Part of the 0.4.3 line.

Resolves ENG-106