### PR TITLE
Add canonical PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,20 +11,22 @@ Preserve existing valid `Refs` or `Resolves` keywords.
 
 ## Primary changes
 
-- <concise summary of the user-visible or reviewer-relevant changes>
+<!-- concise summary of the user-visible or reviewer-relevant changes. -->
 
 ## Reviewer walkthrough
 
-- <ordered files, areas, or flows reviewers should inspect>
+<!-- ordered files, areas, or flows reviewers should inspect. -->
 
 ## Correctness and invariants
 
-- <important invariants, assumptions, compatibility notes, or risk controls>
+<!-- important invariants, assumptions, compatibility notes, or risk controls. -->
 
 ## Testing and QA
 
-- <commands run, checks observed, or manual validation performed>
+<!-- commands run, checks observed, or manual validation performed. -->
 
+## Risk / Rollout
+<!-- Blast radius, migration/ordering notes, follow-ups. -->
 
 Resolves <ISSUE-ID>
 Refs <ISSUE-ID>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+<!--
+Use this template as the canonical PR body shape when creating, repairing, or refreshing pull request bodies.
+
+Required headings are the four `##` headings below, normalized exactly. Preserve accurate existing section content when it still matches the PR, and end the body with one explicit issue reference line for every confidently relevant issue ID:
+
+- `Resolves <ISSUE-ID>` when the issue appears to be resolved by the PR.
+- `Refs <ISSUE-ID>` when the issue is related but not clearly resolved.
+
+Preserve existing valid `Refs` or `Resolves` keywords.
+-->
+
+## Primary changes
+
+- <concise summary of the user-visible or reviewer-relevant changes>
+
+## Reviewer walkthrough
+
+- <ordered files, areas, or flows reviewers should inspect>
+
+## Correctness and invariants
+
+- <important invariants, assumptions, compatibility notes, or risk controls>
+
+## Testing and QA
+
+- <commands run, checks observed, or manual validation performed>
+
+
+Resolves <ISSUE-ID>
+Refs <ISSUE-ID>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Use this template as the canonical PR body shape when creating, repairing, or refreshing pull request bodies.
 
-Required headings are the four `##` headings below, normalized exactly. Preserve accurate existing section content when it still matches the PR, and end the body with one explicit issue reference line for every confidently relevant issue ID:
+Required headings are the five `##` headings below, normalized exactly. Preserve accurate existing section content when it still matches the PR, and end the body with one explicit issue reference line for every confidently relevant issue ID:
 
 - `Resolves <ISSUE-ID>` when the issue appears to be resolved by the PR.
 - `Refs <ISSUE-ID>` when the issue is related but not clearly resolved.


### PR DESCRIPTION
## Primary changes

- Add `.github/PULL_REQUEST_TEMPLATE.md` so GitHub pre-fills new PRs with the maintainer's canonical five-section body shape, ending in explicit `Resolves`/`Refs` issue references.

## Reviewer walkthrough

- `.github/PULL_REQUEST_TEMPLATE.md` — the only file; the canonical template verbatim.

## Correctness and invariants

- Pure addition; no code or CI change. GitHub auto-loads this for newly created PRs; existing PR bodies are untouched.

## Testing and QA

- Markdown only. Confirmed the five `##` headings render and match the supplied canonical template.

## Risk / Rollout

- Zero blast radius — affects only the default body of new PRs, no migration. Minor follow-up: the template's own header comment still says "four `##` headings" while five are now listed; trivial wording fix if wanted.

Part of the 0.4.3 line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdoNJ34uSTtVQNBgHXDVGB)_