### PR TITLE
Drop macos-x64 from the CI manual binary matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,8 +225,10 @@ jobs:
             platform: linux-x64
           - runner: ubuntu-24.04-arm
             platform: linux-arm64
-          - runner: macos-15-intel
-            platform: macos-x64
+          # macos-x64 is intentionally omitted: the macos-15-intel runner
+          # schedules on arm64 hardware in this org, so PyInstaller fails with
+          # IncompatibleBinaryArchError. This matches the release matrix, which
+          # dropped macos-x64 in v0.4.1 (PR #66); x64 macOS installs via PyPI.
           - runner: macos-15
             platform: macos-arm64
 


### PR DESCRIPTION
## Primary changes
- Remove the `macos-x64` / `macos-15-intel` entry from the `build-test` (manual binary) matrix in `.github/workflows/ci.yml`, with a comment explaining why. This makes `workflow_dispatch` CI runs go fully green.

## Reviewer walkthrough
- `.github/workflows/ci.yml` — the `build-test` job's `strategy.matrix.include`: the `macos-15-intel`/`macos-x64` pair is dropped; `linux-x64`, `linux-arm64`, and `macos-arm64` remain.

## Correctness and invariants
- The `macos-15-intel` runner schedules on arm64 hardware in this org, so PyInstaller fails with `IncompatibleBinaryArchError` building an x86_64 target — the same reason the **release** binary matrix dropped `macos-x64` back in v0.4.1 (#66). This change only aligns the CI `build-test` matrix with that decision.
- `build-test` is gated on `if: github.event_name == 'workflow_dispatch'`, so it never runs on pushes or PRs — day-to-day CI and the release pipeline are unaffected. x64 macOS users continue to install from PyPI.

## Testing and QA
- `python3 -c "import yaml; yaml.safe_load(...)"` confirms the workflow YAML still parses.
- Surfaced by a manual `workflow_dispatch` CI run (28269013956) where `macos-x64` was the only failing job (`IncompatibleBinaryArchError`); all other jobs were green.

## Risk / Rollout
- CI-config only; zero blast radius on builds, tests, releases, or generated output. Independent of the held v0.4.3 release PR (#73), but would be captured by the v0.4.3 tag if merged before it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdoNJ34uSTtVQNBgHXDVGB)_