### PR TITLE
[codex] Harden Cloudflare security settings

### DIFF
--- a/website/alchemy.run.ts
+++ b/website/alchemy.run.ts
@@ -1,6 +1,6 @@
 import alchemy from "alchemy";
 import type { Scope } from "alchemy";
-import { Worker } from "alchemy/cloudflare";
+import { Worker, Zone } from "alchemy/cloudflare";
 import { CloudflareStateStore } from "alchemy/state";
 
 import { resolveReleaseConfig } from "./scripts/render-release-config";
@@ -47,6 +47,23 @@ const workerDomains =
   app.stage === "prod" && config.domain !== ""
     ? [{ domainName: config.domain, adopt: true }]
     : undefined;
+
+if (app.stage === "prod" && config.domain !== "") {
+  await Zone("zone-security", {
+    name: config.domain,
+    type: "full",
+    settings: {
+      ssl: "strict",
+      alwaysUseHttps: "on",
+      automaticHttpsRewrites: "on",
+    },
+    botManagement: {
+      fightMode: true,
+      aiBotsProtection: "block",
+      crawlerProtection: "enabled",
+    },
+  });
+}
 
 export const worker = await Worker("website", {
   name: workerName,

--- a/website/src/index.ts
+++ b/website/src/index.ts
@@ -11,6 +11,14 @@ interface Env {
   RELEASE_URL?: string;
 }
 
+const PUBLIC_HOSTNAME = "kickstart-cli.org";
+const HSTS_HEADER_VALUE = "max-age=15552000";
+const SECURITY_TXT = `Contact: mailto:jm@polarcoordinates.org
+Expires: 2027-06-26T00:00:00Z
+Preferred-Languages: en
+Canonical: https://${PUBLIC_HOSTNAME}/.well-known/security.txt
+`;
+
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
     ...init,
@@ -27,6 +35,39 @@ function assetResponse(body: string, contentType: string): Response {
       "cache-control": "no-store",
       "content-type": contentType,
     },
+  });
+}
+
+function securityTextResponse(): Response {
+  return new Response(SECURITY_TXT, {
+    headers: {
+      "cache-control": "public, max-age=3600",
+      "content-type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+function isPublicHostname(hostname: string): boolean {
+  return hostname.toLowerCase() === PUBLIC_HOSTNAME;
+}
+
+function httpsRedirect(url: URL): Response {
+  const redirectUrl = new URL(url);
+  redirectUrl.protocol = "https:";
+  return Response.redirect(redirectUrl.toString(), 308);
+}
+
+function withSecurityHeaders(response: Response, url: URL): Response {
+  if (url.protocol !== "https:" || !isPublicHostname(url.hostname)) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set("strict-transport-security", HSTS_HEADER_VALUE);
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
   });
 }
 
@@ -61,18 +102,32 @@ export default {
     const url = new URL(request.url);
     const service = env.SERVICE_NAME ?? "kickstart-site";
 
+    if (url.protocol === "http:" && isPublicHostname(url.hostname)) {
+      return httpsRedirect(url);
+    }
+
+    if (url.pathname === "/.well-known/security.txt") {
+      return withSecurityHeaders(securityTextResponse(), url);
+    }
+
     if (url.pathname === "/healthz") {
-      return jsonResponse({ status: "ok", service });
+      return withSecurityHeaders(jsonResponse({ status: "ok", service }), url);
     }
 
     if (url.pathname === "/assets/site.css") {
-      return assetResponse(siteStyles, "text/css; charset=utf-8");
+      return withSecurityHeaders(
+        assetResponse(siteStyles, "text/css; charset=utf-8"),
+        url,
+      );
     }
 
     if (url.pathname === "/assets/site.js") {
-      return assetResponse(siteScript, "application/javascript; charset=utf-8");
+      return withSecurityHeaders(
+        assetResponse(siteScript, "application/javascript; charset=utf-8"),
+        url,
+      );
     }
 
-    return htmlResponse(resolveProjectMeta(env));
+    return withSecurityHeaders(htmlResponse(resolveProjectMeta(env)), url);
   },
 } satisfies ExportedHandler<Env>;

--- a/website/tests/worker.test.ts
+++ b/website/tests/worker.test.ts
@@ -19,6 +19,43 @@ describe("kickstart website worker", () => {
     });
   });
 
+  it("redirects the production hostname from HTTP to HTTPS", async () => {
+    const request = new Request("http://kickstart-cli.org/generate") as Parameters<
+      typeof worker.fetch
+    >[0];
+
+    const response = await worker.fetch(request, defaultEnv);
+
+    expect(response.status).toBe(308);
+    expect(response.headers.get("location")).toBe(
+      "https://kickstart-cli.org/generate",
+    );
+  });
+
+  it("adds HSTS on the production hostname", async () => {
+    const request = new Request("https://kickstart-cli.org/") as Parameters<typeof worker.fetch>[0];
+
+    const response = await worker.fetch(request, defaultEnv);
+
+    expect(response.headers.get("strict-transport-security")).toBe(
+      "max-age=15552000",
+    );
+  });
+
+  it("serves security.txt", async () => {
+    const request = new Request("https://kickstart-cli.org/.well-known/security.txt") as Parameters<
+      typeof worker.fetch
+    >[0];
+
+    const response = await worker.fetch(request, defaultEnv);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(body).toContain("Contact: mailto:jm@polarcoordinates.org");
+    expect(body).toContain("Canonical: https://kickstart-cli.org/.well-known/security.txt");
+  });
+
   it("serves the SPA shell", async () => {
     const request = new Request("https://example.test/") as Parameters<typeof worker.fetch>[0];
 


### PR DESCRIPTION
## Summary
- manage strict SSL, Always Use HTTPS, automatic HTTPS rewrites, Bot Fight Mode, AI bot blocking, and AI crawler protection through Alchemy for `kickstart-cli.org`
- serve `/.well-known/security.txt` from the Worker
- add Worker-level HTTP to HTTPS redirect and HSTS headers for the production hostname

## Why
Cloudflare Security Center reported missing `security.txt`, TLS/HSTS/HTTPS hardening, and bot/AI crawler protections for `kickstart-cli.org`.

## Validation
- `rtk bun run check` in `website/`
- live Cloudflare dashboard settings were also updated for the zone