### PR TITLE
Split error models out of error_handling.py; preserve tracebacks in logs

### DIFF
--- a/src/cli/dispatch.py
+++ b/src/cli/dispatch.py
@@ -5,7 +5,7 @@ from typing import Protocol, Unpack
 
 
 from src.cli.options import CreateOptions, ServiceCreateKwargs, SystemCreateKwargs
-from src.utils.error_handling import UnsupportedOptionError, UnsupportedProjectTypeError
+from src.utils.errors import UnsupportedOptionError, UnsupportedProjectTypeError
 from src.utils.types import GeneratorConfig
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -25,7 +25,7 @@ from src.cli.dispatch import ProjectCreators, dispatch_project_creation
 from src.generator.adoption import AdoptionTargetError, inspect_repo
 from src.cli.options import CreateCommandOptions, CreateOptions, ResolvedCreateArgs
 from src.cli.prompts import ConfirmReader, PromptReader, prompt_for_missing_args
-from src.utils.error_handling import KickstartError
+from src.utils.errors import KickstartError
 from src.utils.config import load_config
 from src.utils.installer import (
     BINARY_NAME,

--- a/src/cli/prompts.py
+++ b/src/cli/prompts.py
@@ -5,7 +5,7 @@ from typing import Protocol, cast
 from rich import print
 
 from src.cli.options import CreateCommandOptions, CreateOptions
-from src.utils.error_handling import MissingCreateArgumentsError
+from src.utils.errors import MissingCreateArgumentsError
 from src.utils.types import GeneratorConfig
 
 

--- a/src/generator/adoption.py
+++ b/src/generator/adoption.py
@@ -13,7 +13,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from src.utils.error_handling import KickstartError
+from src.utils.errors import KickstartError
 
 
 class AdoptionTargetError(KickstartError):

--- a/src/generator/base.py
+++ b/src/generator/base.py
@@ -16,8 +16,9 @@ from src.utils.types import GeneratorConfig, TemplateValue, TemplateVars
 from src.utils.error_handling import (
     ErrorCollector, batch_operation_wrapper, handle_file_operations,
     handle_template_operations, safe_operation_context,
-    ensure_directory_exists, InvalidProjectNameError, ProjectCreationError, TemplateError
+    ensure_directory_exists,
 )
+from src.utils.errors import InvalidProjectNameError, ProjectCreationError, TemplateError
 
 logger = logging.getLogger(__name__)
 

--- a/src/generator/lib.py
+++ b/src/generator/lib.py
@@ -11,7 +11,7 @@ from src.generator.template_plan import TemplatePlan
 from src.generator.template_plans import cli_template_plan, library_template_plan
 from src.stack.profile import stack_registry
 from src.stack.types import TemplateConfig
-from src.utils.error_handling import LanguageNotSupportedError
+from src.utils.errors import LanguageNotSupportedError
 from src.utils.github import create_repo
 from src.utils.types import GeneratorConfig
 

--- a/src/generator/service.py
+++ b/src/generator/service.py
@@ -29,9 +29,8 @@ from src.generator.specs import ServiceSpec
 from src.generator.template_plan import TemplatePlan
 from src.utils.types import GeneratorConfig
 from src.utils.types import TemplatePathConfig
-from src.utils.error_handling import (
-    safe_operation_context, LanguageNotSupportedError
-)
+from src.utils.error_handling import safe_operation_context
+from src.utils.errors import LanguageNotSupportedError
 
 logger = logging.getLogger(__name__)
 

--- a/src/generator/service_capabilities.py
+++ b/src/generator/service_capabilities.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from src.utils.error_handling import ExtensionError
+from src.utils.errors import ExtensionError
 
 
 @dataclass(frozen=True)

--- a/src/stack/registry.py
+++ b/src/stack/registry.py
@@ -12,7 +12,7 @@ from src.stack.types import (
     SystemSelection,
     TemplateConfig,
 )
-from src.utils.error_handling import LanguageNotSupportedError
+from src.utils.errors import LanguageNotSupportedError
 from src.utils.types import TemplatePathConfig
 
 

--- a/src/utils/error_handling.py
+++ b/src/utils/error_handling.py
@@ -1,7 +1,8 @@
 """Centralized error handling utilities for kickstart generators.
 
-This module provides standardized error handling patterns, custom exceptions,
-decorators, and utilities to eliminate duplication across the codebase.
+This module provides standardized error handling decorators, context
+managers, and utilities to eliminate duplication across the codebase. The
+exception types themselves live in `src.utils.errors`.
 """
 
 import logging
@@ -10,74 +11,20 @@ from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import ParamSpec, TypeVar
+from src.utils.errors import (
+    DirectoryCreationError,
+    FileOperationError,
+    KickstartError,
+    LanguageNotSupportedError,
+)
 from src.utils.logger import warn
-from src.utils.types import ErrorContext, ErrorContextValue, MutableErrorContext
+from src.utils.types import ErrorContext, ErrorContextValue
 
 logger = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")
-
-
-# Custom Exceptions
-class KickstartError(Exception):
-    """Base exception for all kickstart-related errors."""
-
-    def __init__(self, message: str, context: ErrorContext | None = None) -> None:
-        super().__init__(message)
-        self.message = message
-        self.context: MutableErrorContext = dict(context or {})
-
-
-class ProjectCreationError(KickstartError):
-    """Raised when project creation fails."""
-    pass
-
-
-class TemplateError(KickstartError):
-    """Raised when template operations fail."""
-    pass
-
-
-class DirectoryCreationError(KickstartError):
-    """Raised when directory creation fails."""
-    pass
-
-
-class FileOperationError(KickstartError):
-    """Raised when file operations fail."""
-    pass
-
-
-class LanguageNotSupportedError(KickstartError):
-    """Raised when an unsupported language is specified."""
-    pass
-
-
-class InvalidProjectNameError(KickstartError):
-    """Raised when a project name fails validation."""
-    pass
-
-
-class UnsupportedProjectTypeError(KickstartError):
-    """Raised when a project type has no creator."""
-    pass
-
-
-class UnsupportedOptionError(KickstartError):
-    """Raised when an option does not apply to the selected project type."""
-    pass
-
-
-class MissingCreateArgumentsError(KickstartError):
-    """Raised when required create arguments are absent after prompting."""
-    pass
-
-
-class ExtensionError(KickstartError):
-    """Raised when extension setup fails."""
-    pass
 
 
 # Error Context Manager
@@ -104,7 +51,7 @@ def error_context(operation: str, **context: ErrorContextValue) -> Generator[Non
         raise
     except Exception as e:
         error_msg = f"Operation '{operation}' failed: {e}"
-        logger.error(error_msg, extra=context)
+        logger.error(error_msg, extra=context, exc_info=True)
         raise KickstartError(error_msg, context) from e
 
 
@@ -131,7 +78,7 @@ def handle_file_operations(
                 return func(*args, **kwargs)
             except (OSError, FileNotFoundError, PermissionError) as e:
                 if log_errors:
-                    logger.error(f"File operation failed in {func.__name__}: {e}")
+                    logger.error(f"File operation failed in {func.__name__}: {e}", exc_info=True)
                 if reraise:
                     raise FileOperationError(f"File operation failed: {e}") from e
                 return default_return
@@ -159,7 +106,7 @@ def handle_template_operations(
                 return func(*args, **kwargs)
             except Exception as e:
                 if log_errors:
-                    logger.error(f"Template operation failed in {func.__name__}: {e}")
+                    logger.error(f"Template operation failed in {func.__name__}: {e}", exc_info=True)
                 # Always use warn for user-facing feedback
                 warn(f"Template operation failed: {e}")
                 return default_return
@@ -187,7 +134,7 @@ def handle_directory_operations(
                 return func(*args, **kwargs)
             except OSError as e:
                 if log_errors:
-                    logger.error(f"Directory operation failed in {func.__name__}: {e}")
+                    logger.error(f"Directory operation failed in {func.__name__}: {e}", exc_info=True)
                 warn(f"Directory operation failed: {e}")
                 return default_return
         return wrapper
@@ -232,7 +179,7 @@ def handle_http_operations(
                         error_msg = f"{operation_name} failed with network error: {e}"
 
                 if log_errors:
-                    logger.error(f"HTTP operation failed in {func.__name__}: {error_msg}")
+                    logger.error(f"HTTP operation failed in {func.__name__}: {error_msg}", exc_info=True)
 
                 if reraise:
                     raise KickstartError(error_msg) from e
@@ -266,7 +213,7 @@ def safe_operation(
                 return func(*args, **kwargs)
             except Exception as e:
                 if log_errors:
-                    logger.error(f"{operation_name} failed in {func.__name__}: {e}")
+                    logger.error(f"{operation_name} failed in {func.__name__}: {e}", exc_info=True)
 
                 if reraise_as:
                     raise reraise_as(f"{operation_name} failed: {e}") from e
@@ -298,7 +245,7 @@ def safe_operation_context(
         logger.debug(f"Completed safe operation: {operation_name}")
     except Exception as e:
         if log_errors:
-            logger.error(f"Safe operation '{operation_name}' failed: {e}")
+            logger.error(f"Safe operation '{operation_name}' failed: {e}", exc_info=True)
         if not suppress_exceptions:
             raise
 
@@ -423,8 +370,9 @@ def log_operation_result(
     if success:
         logger.debug(f"{operation} succeeded{target_str}")
     else:
-        error_msg = format_error_message(operation, target or "unknown", error or Exception("Unknown error"), context)
-        logger.error(error_msg)
+        resolved_error = error or Exception("Unknown error")
+        error_msg = format_error_message(operation, target or "unknown", resolved_error, context)
+        logger.error(error_msg, exc_info=resolved_error)
 
 
 def batch_operation_wrapper(

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -1,0 +1,74 @@
+"""Custom exception hierarchy for kickstart.
+
+Every kickstart-specific error derives from `KickstartError`. Keeping the
+models in their own module (separate from `error_handling.py`'s decorators
+and context managers) lets call sites depend on the error types without
+pulling in the handling machinery.
+"""
+
+from src.utils.types import ErrorContext, MutableErrorContext
+
+
+class KickstartError(Exception):
+    """Base exception for all kickstart-related errors."""
+
+    def __init__(self, message: str, context: ErrorContext | None = None) -> None:
+        super().__init__(message)
+        self.message = message
+        self.context: MutableErrorContext = dict(context or {})
+
+    def __str__(self) -> str:
+        if not self.context:
+            return self.message
+        context_str = ", ".join(f"{k}={v}" for k, v in self.context.items())
+        return f"{self.message} (context: {context_str})"
+
+
+class ProjectCreationError(KickstartError):
+    """Raised when project creation fails."""
+    pass
+
+
+class TemplateError(KickstartError):
+    """Raised when template operations fail."""
+    pass
+
+
+class DirectoryCreationError(KickstartError):
+    """Raised when directory creation fails."""
+    pass
+
+
+class FileOperationError(KickstartError):
+    """Raised when file operations fail."""
+    pass
+
+
+class LanguageNotSupportedError(KickstartError):
+    """Raised when an unsupported language is specified."""
+    pass
+
+
+class InvalidProjectNameError(KickstartError):
+    """Raised when a project name fails validation."""
+    pass
+
+
+class UnsupportedProjectTypeError(KickstartError):
+    """Raised when a project type has no creator."""
+    pass
+
+
+class UnsupportedOptionError(KickstartError):
+    """Raised when an option does not apply to the selected project type."""
+    pass
+
+
+class MissingCreateArgumentsError(KickstartError):
+    """Raised when required create arguments are absent after prompting."""
+    pass
+
+
+class ExtensionError(KickstartError):
+    """Raised when extension setup fails."""
+    pass

--- a/tests/integration/test_project_creation.py
+++ b/tests/integration/test_project_creation.py
@@ -18,7 +18,7 @@ from src.generator.service import ServiceGenerator
 from src.generator.frontend import FrontendGenerator
 from src.generator.lib import LibGenerator
 from src.generator.monorepo import MonorepoGenerator
-from src.utils.error_handling import ProjectCreationError, LanguageNotSupportedError
+from src.utils.errors import ProjectCreationError, LanguageNotSupportedError
 from src.utils.types import GeneratorConfig
 
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -11,7 +11,7 @@ from src.cli.main import (
     _resolve_install_context,
     app,
 )
-from src.utils.error_handling import ExtensionError, KickstartError
+from src.utils.errors import ExtensionError, KickstartError
 
 
 @pytest.fixture

--- a/tests/unit/generator/test_frontend.py
+++ b/tests/unit/generator/test_frontend.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, call
 from src.generator.frontend import FrontendGenerator
-from src.utils.error_handling import ProjectCreationError
+from src.utils.errors import ProjectCreationError
 
 
 @pytest.fixture

--- a/tests/unit/generator/test_lib.py
+++ b/tests/unit/generator/test_lib.py
@@ -2,7 +2,7 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, call
 from src.generator.lib import LibraryGenerator, CLIGenerator
-from src.utils.error_handling import ProjectCreationError, LanguageNotSupportedError
+from src.utils.errors import ProjectCreationError, LanguageNotSupportedError
 
 
 @pytest.fixture

--- a/tests/unit/generator/test_monorepo.py
+++ b/tests/unit/generator/test_monorepo.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from unittest.mock import patch, call
 from src.generator.monorepo import MonorepoGenerator
 from src.generator.system import SystemGenerator
-from src.utils.error_handling import ProjectCreationError
+from src.utils.errors import ProjectCreationError
 
 
 def _template_written(mock_write_template, target, template):

--- a/tests/unit/generator/test_service.py
+++ b/tests/unit/generator/test_service.py
@@ -4,7 +4,7 @@ from unittest.mock import patch, call
 from src.generator.language_setup import CPP_MAIN_CONTENT, CPP_ROUTES_HEADER_CONTENT, CPP_USER_HEADER_CONTENT
 from src.generator.service import ServiceGenerator
 from src.generator.scaffold_contract import ScaffoldArtifacts, ScaffoldContract
-from src.utils.error_handling import ProjectCreationError, ExtensionError, LanguageNotSupportedError
+from src.utils.errors import ProjectCreationError, ExtensionError, LanguageNotSupportedError
 
 
 @pytest.fixture

--- a/tests/unit/generator/test_service_capabilities.py
+++ b/tests/unit/generator/test_service_capabilities.py
@@ -3,7 +3,7 @@
 import pytest
 
 from src.generator.service_capabilities import validate_service_extensions
-from src.utils.error_handling import ExtensionError
+from src.utils.errors import ExtensionError
 
 
 def test_python_fastapi_container_accepts_implemented_extensions() -> None:

--- a/tests/unit/stack/test_profile.py
+++ b/tests/unit/stack/test_profile.py
@@ -1,7 +1,7 @@
 import pytest
 
 from src.stack.profile import stack_registry
-from src.utils.error_handling import LanguageNotSupportedError
+from src.utils.errors import LanguageNotSupportedError
 
 
 def test_language_and_runtime_aliases_normalize_to_canonical_ids():

--- a/tests/unit/utils/test_error_handling.py
+++ b/tests/unit/utils/test_error_handling.py
@@ -1,0 +1,463 @@
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.utils.errors import (
+    DirectoryCreationError,
+    FileOperationError,
+    KickstartError,
+    LanguageNotSupportedError,
+)
+from src.utils.error_handling import (
+    ErrorCollector,
+    batch_operation_wrapper,
+    ensure_directory_exists,
+    error_context,
+    format_error_message,
+    handle_directory_operations,
+    handle_file_operations,
+    handle_http_operations,
+    handle_template_operations,
+    log_operation_result,
+    safe_binary_write,
+    safe_file_copy,
+    safe_file_write,
+    safe_operation,
+    safe_operation_context,
+    validate_language_support,
+)
+
+
+# --- error_context ---------------------------------------------------------
+
+def test_error_context_yields_on_success():
+    with error_context("do the thing"):
+        result = 1 + 1
+    assert result == 2
+
+
+def test_error_context_reraises_kickstart_error_unchanged():
+    original = KickstartError("already typed")
+    with pytest.raises(KickstartError) as exc_info:
+        with error_context("do the thing"):
+            raise original
+    assert exc_info.value is original
+
+
+def test_error_context_wraps_other_exceptions_with_context():
+    with pytest.raises(KickstartError) as exc_info:
+        with error_context("do the thing", target="/tmp/x"):
+            raise ValueError("bad value")
+    error = exc_info.value
+    assert "Operation 'do the thing' failed: bad value" in str(error)
+    assert error.context == {"target": "/tmp/x"}
+    assert isinstance(error.__cause__, ValueError)
+
+
+# --- handle_file_operations -------------------------------------------------
+
+def test_handle_file_operations_returns_value_on_success():
+    @handle_file_operations(default_return="default")
+    def op():
+        return "ok"
+
+    assert op() == "ok"
+
+
+def test_handle_file_operations_returns_default_on_error():
+    @handle_file_operations(default_return="default", log_errors=False)
+    def op():
+        raise FileNotFoundError("missing")
+
+    assert op() == "default"
+
+
+def test_handle_file_operations_reraises_as_file_operation_error():
+    @handle_file_operations(default_return=None, reraise=True)
+    def op():
+        raise PermissionError("denied")
+
+    with pytest.raises(FileOperationError):
+        op()
+
+
+def test_handle_file_operations_ignores_other_exceptions():
+    @handle_file_operations(default_return=None)
+    def op():
+        raise ValueError("not a file error")
+
+    with pytest.raises(ValueError):
+        op()
+
+
+# --- handle_template_operations ----------------------------------------------
+
+def test_handle_template_operations_returns_value_on_success():
+    @handle_template_operations(default_return="default")
+    def op():
+        return "ok"
+
+    assert op() == "ok"
+
+
+def test_handle_template_operations_returns_default_and_warns_on_error():
+    @handle_template_operations(default_return="default")
+    def op():
+        raise RuntimeError("template broke")
+
+    with patch("src.utils.error_handling.warn") as mock_warn:
+        assert op() == "default"
+        mock_warn.assert_called_once()
+
+
+# --- handle_directory_operations ---------------------------------------------
+
+def test_handle_directory_operations_returns_value_on_success():
+    @handle_directory_operations(default_return=False)
+    def op():
+        return True
+
+    assert op() is True
+
+
+def test_handle_directory_operations_returns_default_and_warns_on_oserror():
+    @handle_directory_operations(default_return=False)
+    def op():
+        raise OSError("disk full")
+
+    with patch("src.utils.error_handling.warn") as mock_warn:
+        assert op() is False
+        mock_warn.assert_called_once()
+
+
+def test_handle_directory_operations_ignores_non_os_errors():
+    @handle_directory_operations(default_return=False)
+    def op():
+        raise ValueError("nope")
+
+    with pytest.raises(ValueError):
+        op()
+
+
+# --- handle_http_operations ---------------------------------------------------
+
+def test_handle_http_operations_returns_value_on_success():
+    @handle_http_operations("fetch", default_return=None)
+    def op():
+        return {"ok": True}
+
+    assert op() == {"ok": True}
+
+
+def test_handle_http_operations_returns_default_on_generic_exception():
+    @handle_http_operations("fetch", default_return="default")
+    def op():
+        raise RuntimeError("network is down")
+
+    assert op() == "default"
+
+
+def test_handle_http_operations_reraises_as_kickstart_error():
+    @handle_http_operations("fetch", default_return=None, reraise=True)
+    def op():
+        raise RuntimeError("network is down")
+
+    with pytest.raises(KickstartError):
+        op()
+
+
+def test_handle_http_operations_reports_http_status_from_response():
+    import requests
+
+    response = requests.Response()
+    response.status_code = 503
+
+    @handle_http_operations("fetch", default_return=None, reraise=True)
+    def op():
+        raise requests.RequestException("service unavailable", response=response)
+
+    with pytest.raises(KickstartError) as exc_info:
+        op()
+    assert "HTTP 503" in str(exc_info.value)
+
+
+def test_handle_http_operations_reports_network_error_without_response():
+    import requests
+
+    @handle_http_operations("fetch", default_return=None, reraise=True)
+    def op():
+        raise requests.ConnectionError("connection refused")
+
+    with pytest.raises(KickstartError) as exc_info:
+        op()
+    assert "network error" in str(exc_info.value)
+
+
+# --- safe_operation -------------------------------------------------------------
+
+def test_safe_operation_returns_value_on_success():
+    @safe_operation("do thing", default_return="default")
+    def op():
+        return "ok"
+
+    assert op() == "ok"
+
+
+def test_safe_operation_returns_default_on_error_without_reraise():
+    @safe_operation("do thing", default_return="default")
+    def op():
+        raise RuntimeError("boom")
+
+    assert op() == "default"
+
+
+def test_safe_operation_reraises_as_requested_type():
+    @safe_operation("do thing", reraise_as=KickstartError)
+    def op():
+        raise RuntimeError("boom")
+
+    with pytest.raises(KickstartError):
+        op()
+
+
+# --- safe_operation_context -------------------------------------------------------
+
+def test_safe_operation_context_yields_on_success():
+    with safe_operation_context("do thing"):
+        result = 1 + 1
+    assert result == 2
+
+
+def test_safe_operation_context_suppresses_exceptions_by_default():
+    with safe_operation_context("do thing"):
+        raise RuntimeError("boom")
+
+
+def test_safe_operation_context_reraises_when_not_suppressing():
+    with pytest.raises(RuntimeError):
+        with safe_operation_context("do thing", suppress_exceptions=False):
+            raise RuntimeError("boom")
+
+
+# --- ErrorCollector -------------------------------------------------------------
+
+def test_error_collector_tracks_success_and_totals():
+    collector = ErrorCollector("batch")
+    collector.increment_total()
+    collector.increment_success()
+    assert collector.success_count == 1
+    assert collector.total_count == 1
+    assert not collector.has_errors()
+    assert not collector.has_warnings()
+
+
+def test_error_collector_add_error_and_warning():
+    collector = ErrorCollector("batch")
+    collector.add_error("bad thing")
+    collector.add_warning("meh thing")
+    assert collector.has_errors()
+    assert collector.has_warnings()
+    assert collector.errors == ["bad thing"]
+    assert collector.warnings == ["meh thing"]
+
+
+def test_error_collector_get_summary_reports_counts():
+    collector = ErrorCollector("batch")
+    collector.increment_total()
+    collector.increment_total()
+    collector.increment_success()
+    collector.add_error("bad")
+    collector.add_warning("meh")
+    summary = collector.get_summary()
+    assert "1/2 operations successful" in summary
+    assert "1 errors" in summary
+    assert "1 warnings" in summary
+
+
+def test_error_collector_log_summary_warns_user_when_errors_present():
+    collector = ErrorCollector("batch")
+    collector.add_error("bad")
+    with patch("src.utils.error_handling.warn") as mock_warn:
+        collector.log_summary()
+        mock_warn.assert_called_once()
+
+
+def test_error_collector_log_summary_clean_when_only_warnings(caplog):
+    collector = ErrorCollector("batch")
+    collector.add_warning("meh")
+    with caplog.at_level(logging.WARNING, logger="src.utils.error_handling"):
+        collector.log_summary()
+    assert any("meh" in message for message in caplog.messages)
+
+
+def test_error_collector_log_summary_clean_when_no_issues(caplog):
+    collector = ErrorCollector("batch")
+    collector.increment_total()
+    collector.increment_success()
+    with caplog.at_level(logging.INFO, logger="src.utils.error_handling"):
+        collector.log_summary()
+    assert any("1/1 operations successful" in message for message in caplog.messages)
+
+
+def test_error_collector_report_failures_reports_errors_and_warnings():
+    collector = ErrorCollector("batch")
+    collector.add_error("bad")
+    collector.add_warning("meh")
+    with patch("src.utils.error_handling.warn") as mock_warn:
+        collector.report_failures()
+        mock_warn.assert_called_once()
+        assert "bad" in mock_warn.call_args[0][0]
+
+
+def test_error_collector_report_failures_noop_when_clean():
+    collector = ErrorCollector("batch")
+    with patch("src.utils.error_handling.warn") as mock_warn:
+        collector.report_failures()
+        mock_warn.assert_not_called()
+
+
+# --- format_error_message / log_operation_result --------------------------------
+
+def test_format_error_message_without_context():
+    message = format_error_message("write", "/tmp/x", ValueError("bad"))
+    assert message == "write failed for '/tmp/x': bad"
+
+
+def test_format_error_message_with_context():
+    message = format_error_message("write", "/tmp/x", ValueError("bad"), {"attempt": 2})
+    assert message == "write failed for '/tmp/x': bad (context: attempt=2)"
+
+
+def test_log_operation_result_success(caplog):
+    with caplog.at_level(logging.DEBUG, logger="src.utils.error_handling"):
+        log_operation_result("write", success=True, target="/tmp/x")
+    assert any("write succeeded for '/tmp/x'" in message for message in caplog.messages)
+
+
+def test_log_operation_result_failure_with_error(caplog):
+    with caplog.at_level(logging.ERROR, logger="src.utils.error_handling"):
+        log_operation_result("write", success=False, target="/tmp/x", error=ValueError("bad"))
+    assert any("write failed for '/tmp/x': bad" in message for message in caplog.messages)
+
+
+def test_log_operation_result_failure_without_error_uses_default(caplog):
+    with caplog.at_level(logging.ERROR, logger="src.utils.error_handling"):
+        log_operation_result("write", success=False)
+    assert any("Unknown error" in message for message in caplog.messages)
+
+
+# --- batch_operation_wrapper -----------------------------------------------------
+
+def test_batch_operation_wrapper_all_succeed():
+    collector = batch_operation_wrapper([1, 2, 3], lambda item: True, "batch")
+    assert collector.success_count == 3
+    assert collector.total_count == 3
+    assert not collector.has_errors()
+
+
+def test_batch_operation_wrapper_records_failures():
+    collector = batch_operation_wrapper(
+        [1, 2], lambda item: item != 2, "batch", item_name_func=lambda item: f"item-{item}"
+    )
+    assert collector.success_count == 1
+    assert collector.errors == ["Operation failed for item-2"]
+
+
+def test_batch_operation_wrapper_records_exceptions():
+    def blow_up(item):
+        raise RuntimeError("kaboom")
+
+    collector = batch_operation_wrapper([1], blow_up, "batch")
+    assert collector.total_count == 1
+    assert collector.success_count == 0
+    assert "Exception processing 1: kaboom" in collector.errors[0]
+
+
+# --- validate_language_support ---------------------------------------------------
+
+def test_validate_language_support_accepts_supported_language():
+    validate_language_support("python", ["python", "rust"])
+
+
+def test_validate_language_support_rejects_unsupported_language():
+    with pytest.raises(LanguageNotSupportedError):
+        validate_language_support("cobol", ["python", "rust"])
+
+
+# --- ensure_directory_exists -------------------------------------------------------
+
+def test_ensure_directory_exists_true_when_already_present(tmp_path: Path):
+    assert ensure_directory_exists(tmp_path) is True
+
+
+def test_ensure_directory_exists_false_when_missing_and_create_disabled(tmp_path: Path):
+    missing = tmp_path / "missing"
+    assert ensure_directory_exists(missing, create=False) is False
+
+
+def test_ensure_directory_exists_creates_directory(tmp_path: Path):
+    target = tmp_path / "nested" / "dir"
+    assert ensure_directory_exists(target) is True
+    assert target.is_dir()
+
+
+def test_ensure_directory_exists_raises_on_oserror(tmp_path: Path):
+    target = tmp_path / "dir"
+    with patch("pathlib.Path.mkdir", side_effect=OSError("no space")):
+        with pytest.raises(DirectoryCreationError):
+            ensure_directory_exists(target)
+
+
+# --- safe_binary_write / safe_file_write / safe_file_copy ---------------------------
+
+def test_safe_binary_write_writes_bytes_and_sets_permissions(tmp_path: Path):
+    target = tmp_path / "nested" / "file.bin"
+    assert safe_binary_write(target, b"data", permissions=0o644) is True
+    assert target.read_bytes() == b"data"
+
+
+def test_safe_binary_write_raises_file_operation_error(tmp_path: Path):
+    target = tmp_path / "file.bin"
+    with patch("pathlib.Path.write_bytes", side_effect=OSError("disk full")):
+        with pytest.raises(FileOperationError):
+            safe_binary_write(target, b"data")
+
+
+def test_safe_file_write_writes_text(tmp_path: Path):
+    target = tmp_path / "nested" / "file.txt"
+    assert safe_file_write(target, "hello") is True
+    assert target.read_text() == "hello"
+
+
+def test_safe_file_write_raises_file_operation_error(tmp_path: Path):
+    target = tmp_path / "file.txt"
+    with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+        with pytest.raises(FileOperationError):
+            safe_file_write(target, "hello")
+
+
+def test_safe_file_copy_preserves_metadata_by_default(tmp_path: Path):
+    source = tmp_path / "source.txt"
+    source.write_text("hello")
+    target = tmp_path / "nested" / "target.txt"
+    assert safe_file_copy(source, target) is True
+    assert target.read_text() == "hello"
+
+
+def test_safe_file_copy_without_preserving_metadata(tmp_path: Path):
+    source = tmp_path / "source.txt"
+    source.write_text("hello")
+    target = tmp_path / "target.txt"
+    assert safe_file_copy(source, target, preserve_metadata=False) is True
+    assert target.read_text() == "hello"
+
+
+def test_safe_file_copy_raises_file_operation_error(tmp_path: Path):
+    source = tmp_path / "source.txt"
+    source.write_text("hello")
+    target = tmp_path / "target.txt"
+    with patch("shutil.copy2", side_effect=OSError("disk full")):
+        with pytest.raises(FileOperationError):
+            safe_file_copy(source, target)

--- a/tests/unit/utils/test_errors.py
+++ b/tests/unit/utils/test_errors.py
@@ -1,0 +1,86 @@
+import pytest
+
+from src.utils.errors import (
+    DirectoryCreationError,
+    ExtensionError,
+    FileOperationError,
+    InvalidProjectNameError,
+    KickstartError,
+    LanguageNotSupportedError,
+    MissingCreateArgumentsError,
+    ProjectCreationError,
+    TemplateError,
+    UnsupportedOptionError,
+    UnsupportedProjectTypeError,
+)
+
+SUBCLASSES = (
+    ProjectCreationError,
+    TemplateError,
+    DirectoryCreationError,
+    FileOperationError,
+    LanguageNotSupportedError,
+    InvalidProjectNameError,
+    UnsupportedProjectTypeError,
+    UnsupportedOptionError,
+    MissingCreateArgumentsError,
+    ExtensionError,
+)
+
+
+def test_kickstart_error_without_context_str_is_just_message():
+    error = KickstartError("something failed")
+    assert str(error) == "something failed"
+    assert error.message == "something failed"
+    assert error.context == {}
+
+
+def test_kickstart_error_with_context_appends_it_to_str():
+    error = KickstartError("something failed", {"path": "/tmp/x", "attempt": 2})
+    assert str(error) == "something failed (context: path=/tmp/x, attempt=2)"
+
+
+def test_kickstart_error_context_defaults_to_empty_dict_when_none():
+    error = KickstartError("failed", None)
+    assert error.context == {}
+
+
+def test_kickstart_error_context_is_mutable_copy():
+    context = {"key": "value"}
+    error = KickstartError("failed", context)
+    error.context["key"] = "changed"
+    assert context["key"] == "value"
+
+
+def test_kickstart_error_is_an_exception():
+    with pytest.raises(KickstartError):
+        raise KickstartError("boom")
+
+
+@pytest.mark.parametrize("error_cls", SUBCLASSES)
+def test_subclasses_are_kickstart_errors(error_cls):
+    error = error_cls("boom")
+    assert isinstance(error, KickstartError)
+    assert str(error) == "boom"
+
+
+@pytest.mark.parametrize("error_cls", SUBCLASSES)
+def test_subclasses_carry_context_in_str(error_cls):
+    error = error_cls("boom", {"k": "v"})
+    assert str(error) == "boom (context: k=v)"
+
+
+def test_subclasses_are_distinguishable_from_each_other():
+    assert not isinstance(ProjectCreationError("x"), TemplateError)
+    assert not isinstance(TemplateError("x"), ProjectCreationError)
+
+
+def test_kickstart_error_chains_cause():
+    original = ValueError("root cause")
+    try:
+        try:
+            raise original
+        except ValueError as exc:
+            raise KickstartError("wrapped") from exc
+    except KickstartError as error:
+        assert error.__cause__ is original


### PR DESCRIPTION
## Summary
- Move `KickstartError` and its 10 subclasses out of `src/utils/error_handling.py` into a new `src/utils/errors.py`, so the exception hierarchy ("models") is separate from the decorators/context managers that handle them.
- `KickstartError.__str__` now surfaces captured `context` instead of silently dropping it wherever the error is printed or logged.
- Every catch block in `error_handling.py` that logs an exception now passes `exc_info` (or the exception itself) so the real traceback lands in logs instead of only the string message.
- Update imports across CLI, generator, and stack modules (and their tests) to pull exception types from `src.utils.errors`.

Test coverage for these modules is raised in a follow-up PR (stacked on this branch) to keep this change focused on the refactor.

## Test plan
- [x] `make lint`
- [x] `make typecheck`
- [x] `make tests` (445 passed)
- [x] `make check`