### PR TITLE
Raise kickstart TemplateError from template rendering in fs.py

### DIFF
--- a/src/utils/fs.py
+++ b/src/utils/fs.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import logging
 from jinja2 import Environment, FileSystemLoader, DictLoader, Template
-from jinja2.exceptions import TemplateError, TemplateNotFound
+from jinja2.exceptions import TemplateError as Jinja2TemplateError, TemplateNotFound
+from src.utils.error_handling import TemplateError
 from src.utils.types import MutableRenderVars, RenderValue, RenderVars
 
 logger = logging.getLogger(__name__)
@@ -91,7 +92,7 @@ class TemplateEngine:
         except TemplateNotFound as e:
             logger.error(f"Template not found: {template_path}")
             raise FileNotFoundError(f"Template not found: {template_path}") from e
-        except TemplateError as e:
+        except Jinja2TemplateError as e:
             logger.error(f"Template rendering error in {template_path}: {e}")
             raise TemplateError(f"Template rendering failed: {e}") from e
         except UnicodeDecodeError as e:
@@ -114,7 +115,7 @@ class TemplateEngine:
         try:
             template = self.env.from_string(template_content)
             return template.render(**variables)
-        except TemplateError as e:
+        except Jinja2TemplateError as e:
             logger.error(f"String template rendering error: {e}")
             raise TemplateError(f"String template rendering failed: {e}") from e
 
@@ -144,7 +145,9 @@ def write_file(path: Path, template: Path | str, **vars: RenderValue) -> None:
 
     Raises:
         OSError: If file cannot be written
-        TemplateError: If template rendering fails
+
+    Template rendering failures do not raise; they fall back to legacy
+    placeholder replacement.
     """
     render_vars = _with_legacy_variable_aliases(vars)
 

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -1,4 +1,7 @@
-from src.utils.fs import write_file
+import pytest
+
+from src.utils.error_handling import KickstartError, TemplateError
+from src.utils.fs import TemplateEngine, write_file
 
 def test_write_file_with_path_template(tmp_path):
     template_path = tmp_path / "template.txt"
@@ -35,6 +38,27 @@ def test_write_file_with_multiple_variables(tmp_path):
 def test_write_file_with_no_variables(tmp_path):
     output_path = tmp_path / "output.txt"
     write_file(output_path, "Hello World")
-    
+
     assert output_path.exists()
-    assert output_path.read_text() == "Hello World" 
+    assert output_path.read_text() == "Hello World"
+
+def test_render_string_with_invalid_syntax_raises_kickstart_template_error():
+    engine = TemplateEngine()
+
+    with pytest.raises(TemplateError) as exc_info:
+        engine.render_string("Hello {% if name %}", {"name": "World"})
+
+    assert isinstance(exc_info.value, KickstartError)
+    assert exc_info.value.__cause__ is not None
+
+def test_render_template_with_invalid_syntax_raises_kickstart_template_error(tmp_path):
+    template_path = tmp_path / "broken.txt"
+    template_path.write_text("Hello {% if name %}")
+
+    engine = TemplateEngine()
+
+    with pytest.raises(TemplateError) as exc_info:
+        engine.render_template(template_path, {"name": "World"})
+
+    assert isinstance(exc_info.value, KickstartError)
+    assert exc_info.value.__cause__ is not None


### PR DESCRIPTION
## Primary changes

`src/utils/fs.py` imported `TemplateError` from `jinja2.exceptions` and re-raised that same jinja2 class on rendering failures — a completely different class from `src.utils.error_handling.TemplateError` (a `KickstartError` subclass) used everywhere else. Since jinja2's class does not inherit `KickstartError`, template rendering failures escaping `fs.py` bypassed the CLI's `except KickstartError` handlers and fell through to the generic `Exception` handler, losing the clean "Failed to create project: ..." messaging and the typed-exception contract.

- Alias the jinja2 import as `Jinja2TemplateError`, catch it in the except clauses, and raise the kickstart `TemplateError` instead — consistent with `src/generator/base.py:144`.
- Fix `write_file`'s docstring: template failures never propagate from it (both branches fall back to legacy placeholder replacement); only `OSError` raises.

## Reviewer walkthrough

1. `src/utils/fs.py:4-5` — jinja2's `TemplateError` aliased; kickstart `TemplateError` imported from `src.utils.error_handling`.
2. `src/utils/fs.py:95, 118` — except clauses catch `Jinja2TemplateError`; the raise sites (97, 100, 120) now raise the kickstart class.
3. `src/utils/fs.py:146-150` — corrected `write_file` raise-contract docstring.

## Correctness and invariants

- Except-clause ordering preserved: `TemplateNotFound` (a subclass of jinja2's `TemplateError`) is caught first and still maps to `FileNotFoundError`.
- All jinja2 template exceptions (`TemplateSyntaxError`, `UndefinedError`, `TemplateRuntimeError`, etc.) subclass jinja2's `TemplateError`, so `except Jinja2TemplateError` covers the same set as before; `from e` chaining preserves the original as `__cause__`.
- `write_file`'s internal legacy-fallback except clauses now bind to the kickstart `TemplateError`, exactly matching what the engine raises, so fallback behavior is unchanged.
- Nothing in the repo imports `TemplateError` from `src.utils.fs` or catches jinja2 exceptions elsewhere; no circular import (`error_handling` depends only on leaf modules `logger`/`types`).
- The one call site whose escaping class changes — `render_string` at `src/generator/base.py:214` — now reaches `except KickstartError` in `src/cli/main.py:541`, which is the intended fix.

## Testing and QA

- `make check` passes: ruff, mypy, type hygiene, template audit, 445 tests.
- Runtime-verified in the poetry env: broken string and file templates raise `src.utils.error_handling.TemplateError` (`isinstance KickstartError=True`) with the jinja2 original as `__cause__`; a missing named template still raises `FileNotFoundError`; both `write_file` fallback branches still write legacy-replaced output with no exception escaping.

## Risk / Rollout

- Blast radius is limited to the exception class raised from `TemplateEngine.render_template`/`render_string`; all in-repo handlers are either class-agnostic (`except Exception`) or `except KickstartError`, so behavior only changes where intended (CLI error messaging). No migration or follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)