### PR TITLE
Fix broken master: import TemplateError from src.utils.errors

### DIFF
--- a/src/utils/fs.py
+++ b/src/utils/fs.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import logging
 from jinja2 import Environment, FileSystemLoader, DictLoader, Template
 from jinja2.exceptions import TemplateError as Jinja2TemplateError, TemplateNotFound
-from src.utils.error_handling import TemplateError
+from src.utils.errors import TemplateError
 from src.utils.types import MutableRenderVars, RenderValue, RenderVars
 
 logger = logging.getLogger(__name__)

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.utils.error_handling import KickstartError, TemplateError
+from src.utils.errors import KickstartError, TemplateError
 from src.utils.fs import TemplateEngine, write_file
 
 def test_write_file_with_path_template(tmp_path):


### PR DESCRIPTION
## Primary changes

Master's CI is currently broken across every job (`ImportError: cannot import name 'TemplateError' from 'src.utils.error_handling'`), caused by a merge-order conflict between two independently-developed PRs:

- #78 (merged first) split the exception hierarchy out of `src/utils/error_handling.py` into a new `src/utils/errors.py` module.
- #81 (merged second) was written against the pre-refactor layout and added `from src.utils.error_handling import TemplateError` to `src/utils/fs.py` — a name `error_handling.py` no longer exports.

Since neither branch was rebased on the other before merging, master ended up broken: the package fails to import at all, taking every test, lint, and coverage job down with it (see [run 29021698898](https://github.com/woud420/kickstart/actions/runs/29021698898)).

Fix: import `TemplateError` (and `KickstartError`, in the test file) from `src.utils.errors` instead, matching how `src/generator/base.py` already imports it post-refactor.

## Reviewer walkthrough

1. `src/utils/fs.py:5` — `from src.utils.error_handling import TemplateError` → `from src.utils.errors import TemplateError`.
2. `tests/unit/utils/test_fs.py:3` — same fix for `KickstartError`/`TemplateError`.

## Correctness and invariants

- `src/utils/errors.py` is where `KickstartError`, `TemplateError`, and the rest of the exception hierarchy now live post-#78; `error_handling.py` only re-exports the subset it uses internally (which doesn't include `TemplateError`).
- Repo-wide grep confirms no other stale `TemplateError`/`KickstartError` imports from `error_handling`.

## Testing and QA

- `make check` on this branch (built off current `master`, i.e. #78 + #80 + #81 combined): ruff, mypy, type hygiene, template audit, and the full suite — **526 tests pass**.

## Risk / Rollout

- Minimal, single-purpose import fix. No behavior change — restores master to the state both merged PRs individually verified in CI before the merge-order conflict surfaced. Should merge immediately since master is currently broken for anyone building off it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)