### PR TITLE
Make the release pipeline fail loudly instead of green-skipping

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -22,7 +22,12 @@ current release line, or prepare a release PR. The full policy is
 3. Update the dev-vars fallback in `website/wrangler.toml`
    (`PROJECT_VERSION`, `RELEASE_URL`) and the `defaultConfig` fallback in
    `website/scripts/render-release-config.ts`.
-4. Verify everything locally:
+4. Regenerate the committed golden fixture (procedure in
+   `docs/contributing.md`). The version bump changes the `semantics` URL
+   inside the fixture's `.kickstart/scaffold.json`, so `make check` fails
+   with a golden-fixture diff until the fixture is regenerated — this is
+   expected, not a template bug.
+5. Verify everything locally:
 
    ```bash
    make check
@@ -30,25 +35,37 @@ current release line, or prepare a release PR. The full policy is
    make release-check TAG=vX.Y.Z
    ```
 
-5. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit
+6. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit
    automatically when the `RELEASE_TAG_TOKEN` secret is configured (it
    re-runs `make release-check` first and never moves an existing tag).
-   Without the secret, tag and push manually:
+   Without the secret the workflow fails — tag and push manually, pointing
+   the tag at the version-bump merge commit (never bare `git tag` on a
+   checkout whose HEAD may have advanced past the bump):
 
    ```bash
-   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git tag -a vX.Y.Z -m "Release vX.Y.Z" <version-bump-merge-commit>
    git push origin vX.Y.Z
    ```
 
-6. Watch the release workflow: verify → package (PyPI) → binary
-   (linux-x64, linux-arm64, macos-arm64 at py3.14) → GitHub Release →
-   website deploy. All jobs must be green, including Deploy Website.
+7. Watch the release workflow: verify (incl. the website version-sync
+   gate) → package → binary (linux-x64, linux-arm64, macos-arm64 at
+   py3.14) → GitHub Release → website deploy. All jobs must be green,
+   including Deploy Website.
+8. Confirm the release is not stranded before reporting done:
+   `git ls-remote --tags origin` lists `vX.Y.Z`, the GitHub Release for
+   the tag exists, and https://kickstart-cli.org shows the new version.
+   A merged bump with no tag blocks all same-version retags until fixed.
 
 ## Same-Version Updates
 
 For docs, website copy, tests, or non-behavior fixes: do not bump the
 version. Merge, then retag the current release line onto the new `master`
-HEAD. Release assets are overwritten; PyPI publish skips existing artifacts.
+HEAD. Release assets are overwritten.
+
+Precondition: the current version must actually be tagged. A
+merged-but-untagged version bump makes every same-version retag fail
+`release-check` (each post-bump commit carries the pending version) — tag
+the pending version first.
 
 ## Rules
 

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,8 +11,10 @@ name: Auto Tag Release
 #     not trigger other workflows (GitHub's anti-recursion rule), so the
 #     release pipeline would silently never run. The push therefore
 #     requires the RELEASE_TAG_TOKEN secret (fine-grained PAT with
-#     contents: read/write); without it this workflow skips loudly
-#     instead of creating a tag that goes nowhere.
+#     contents: read/write); without it this workflow FAILS, so a merged
+#     version bump can never sit untagged unnoticed (v0.4.3 was stranded
+#     for two weeks by a green "skip"). The failure email to the merge
+#     author is the alarm; it also catches a PAT that silently expired.
 
 on:
   push:
@@ -21,8 +23,11 @@ on:
     paths:
       - pyproject.toml
       - src/__init__.py
-  # Manual trigger for versions whose bump merged before this workflow
-  # existed (e.g. v0.4.2); the same gates apply.
+  # Manual trigger for versions whose bump merged while the workflow or
+  # its secret was missing; the same gates apply. Careful: a dispatch tags
+  # the checked-out HEAD of the selected ref. When master has advanced
+  # past the version bump, do NOT dispatch — tag the bump commit manually
+  # per docs/release-policy.md instead.
   workflow_dispatch:
 
 permissions:
@@ -61,21 +66,22 @@ jobs:
         if: steps.version.outputs.exists == 'false'
         run: make release-check TAG="${{ steps.version.outputs.tag }}"
 
+      # This step only executes when a new tag is genuinely needed (the
+      # paths trigger plus the exists guard above), so failing here has
+      # zero false positives — and unlike a notice on a green run, a
+      # failed run notifies the merge author.
       - name: Check tagging credentials
-        id: credentials
         if: steps.version.outputs.exists == 'false'
         env:
           RELEASE_TAG_TOKEN: ${{ secrets.RELEASE_TAG_TOKEN }}
         run: |
-          if [ -n "$RELEASE_TAG_TOKEN" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::RELEASE_TAG_TOKEN is not configured. Skipping auto-tag for ${{ steps.version.outputs.tag }} — tags pushed with the default GITHUB_TOKEN cannot trigger the release workflow. Tag manually per docs/release-policy.md."
+          if [ -z "$RELEASE_TAG_TOKEN" ]; then
+            echo "::error::RELEASE_TAG_TOKEN is not configured — ${{ steps.version.outputs.tag }} is merged but cannot be auto-tagged, and tags pushed with the default GITHUB_TOKEN cannot trigger the release workflow. Tag manually per docs/release-policy.md, then configure the secret so the next bump tags itself."
+            exit 1
           fi
 
       - name: Create and push release tag
-        if: steps.version.outputs.exists == 'false' && steps.credentials.outputs.ready == 'true'
+        if: steps.version.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,21 @@ jobs:
       - name: Run checks
         run: make check
 
+      # The website version-sync test (content.ts <-> pyproject.toml) must
+      # gate the release BEFORE anything publishes; the website job below
+      # runs after the GitHub Release exists, which is too late to stop a
+      # desynced changelog from shipping.
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - name: Check website (version sync gate)
+        working-directory: website
+        run: |
+          bun install --frozen-lockfile
+          bun run check
+
   package:
     name: Build Python Package
     runs-on: ubuntu-latest
@@ -239,9 +254,15 @@ jobs:
         run: |
           if [ -n "$CLOUDFLARE_ACCOUNT_ID" ] && [ -n "$CLOUDFLARE_API_TOKEN" ]; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
+          elif [ "$GITHUB_REPOSITORY" = "woud420/kickstart" ]; then
+            # On the canonical repo a missing credential means the public
+            # site silently stops tracking releases — fail instead of
+            # green-skipping (the pattern that stranded v0.4.3 untagged).
+            echo "::error::Cloudflare website credentials are not configured; the release website deploy cannot run. Configure the CLOUDFLARE_ACCOUNT_ID variable and CLOUDFLARE_WEBSITE_API_TOKEN secret."
+            exit 1
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "Cloudflare website credentials are not configured; skipping website deploy."
+            echo "Cloudflare website credentials are not configured; skipping website deploy (fork)."
           fi
 
       - name: Deploy website with Alchemy

--- a/.github/workflows/scheduled-evals.yml
+++ b/.github/workflows/scheduled-evals.yml
@@ -53,3 +53,43 @@ jobs:
           name: bootstrap-eval-report
           path: /tmp/bootstrap-eval.md
           retention-days: 30
+
+  # A merged version bump whose tag never got pushed is a stranded release:
+  # master, the changelog, and generated manifests claim a version that users
+  # cannot install and whose semantics URL 404s. Auto Tag Release now fails
+  # loudly at bump time, but this weekly check also catches the strand modes
+  # that happen later: a tag pushed while the Release workflow failed, or a
+  # revoked/expired credential discovered only on the next release.
+  release-drift:
+    name: Release Drift Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify the current version is tagged and released
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if ! git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::pyproject.toml is ${VERSION} but tag v${VERSION} does not exist — the release is stranded. Tag the version-bump commit per docs/release-policy.md."
+            exit 1
+          fi
+          if ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" --silent; then
+            echo "::error::Tag v${VERSION} exists but has no GitHub Release — the release workflow likely failed. Re-run it for the tag."
+            exit 1
+          fi
+
+      # Every generated .kickstart/scaffold.json pins its semantics URL to
+      # the generating version's tag; a 404 here means every manifest cut
+      # from this source tree carries a dead contract link.
+      - name: Verify the manifest semantics URL resolves
+        run: |
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          URL="https://github.com/${GITHUB_REPOSITORY}/blob/v${VERSION}/docs/scaffold-contract.md"
+          if ! curl -fsSLo /dev/null "$URL"; then
+            echo "::error::Manifest semantics URL does not resolve: ${URL}"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 Notable changes per release. The website release section
 (`website/src/site/content.ts`) carries the same entries and is
-test-enforced to include the current `pyproject.toml` version, so the
-public changelog cannot silently fall behind a release.
+test-enforced to include the current `pyproject.toml` version — in
+`bun run check`, per-PR CI, and the release workflow's verify job — so
+the website source cannot fall behind a version bump. Deployed-site
+parity is a release-time property: the site updates when the release
+tag's Deploy Website job runs, and the weekly release-drift check fails
+if a merged version ever sits untagged.
 
 Release mechanics live in [docs/release-policy.md](docs/release-policy.md).
 
@@ -29,7 +33,7 @@ but the development and release machinery around kickstart got materially better
   (`docs/decisions/headroom-benchmark-learnings.md`).
 - Test coverage: `make coverage` measures `src/` + `ci/` (88.1% baseline); a CI
   job uploads to Codecov (fail-soft without the token). The README leads with
-  CI, Release, Scheduled Evals, Codecov, latest-release, and PyPI badges.
+  CI, Release, Scheduled Evals, Codecov, and latest-release badges.
 
 ### Changed
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ The TypeScript Cloudflare Worker scaffold has a committed golden fixture at:
 - `tests/fixtures/golden/service-hello-worker-typescript-cloudflare-worker`
 - validated by `tests/integration/test_scaffold_golden.py`
 
-When intentional generator changes affect this scaffold, regenerate and review the fixture diff:
+When intentional generator changes affect this scaffold — including version bumps, which change the `semantics` URL inside the fixture's `.kickstart/scaffold.json` — regenerate and review the fixture diff:
 
 ```bash
 tmpdir=$(mktemp -d)
@@ -58,7 +58,7 @@ Release tags must be stable semantic versions like `v0.4.1`. The tag must match 
 
 Run `make release-check TAG=v0.4.1` before pushing a release tag.
 
-Use a new patch/minor/major version for behavior or installable output changes. For docs, website copy, tests, or other same-version fixes, retag the current release line after merge so CI updates the existing GitHub Release instead of creating a new version. On reused tags, GitHub Release assets are overwritten while PyPI publish skips already-existing package artifacts for that version.
+Use a new patch/minor/major version for behavior or installable output changes. For docs, website copy, tests, or other same-version fixes, retag the current release line after merge so CI updates the existing GitHub Release instead of creating a new version. On reused tags, GitHub Release assets are overwritten. Same-version retags only work while the current version is actually tagged — a merged-but-untagged version bump fails `release-check` on every retag until the pending version ships, so tag pending bumps first.
 
 See [Release Policy](release-policy.md) for the full contract.
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -21,16 +21,19 @@ make release-check TAG=v0.4.1
 Use a new version when generated behavior, installable output, public CLI behavior, or release assets change.
 
 1. Update `pyproject.toml` and `src/__init__.py:__version__` together.
-2. Add the release entry to `CHANGELOG.md` and `website/src/site/content.ts` (website tests fail when the current version has no release note).
-3. Merge the change to `master`.
-4. The `Auto Tag Release` workflow tags the merge commit with `vX.Y.Z` automatically when the `RELEASE_TAG_TOKEN` secret (fine-grained PAT, `contents: read/write`) is configured. It never moves an existing tag and only tags after `make release-check` passes. Without the secret it skips with a notice — tag and push manually instead:
+2. Add the release entry to `CHANGELOG.md` and `website/src/site/content.ts` (the website tests fail when the current version has no release note; they run in `bun run check`, per-PR CI, and the release workflow's verify job before anything publishes).
+3. Regenerate the committed golden fixture (procedure in [docs/contributing.md](contributing.md)) — the version bump changes the `semantics` URL inside the fixture's `.kickstart/scaffold.json`, so `make check` fails until the fixture matches.
+4. Merge the change to `master`.
+5. The `Auto Tag Release` workflow tags the merge commit with `vX.Y.Z` automatically when the `RELEASE_TAG_TOKEN` secret (fine-grained PAT, `contents: read/write`) is configured. It never moves an existing tag and only tags after `make release-check` passes. Without the secret the workflow **fails** (it used to skip on a green run, which stranded v0.4.3 untagged for two weeks) — tag and push manually instead, pointing the tag at the **version-bump merge commit**, not `master` HEAD, which may have advanced past the bump and would ship changes the changelog does not cover:
 
 ```bash
-git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git tag -a vX.Y.Z -m "Release vX.Y.Z" <version-bump-merge-commit>
 git push origin vX.Y.Z
 ```
 
 The tag push uses a PAT because tags pushed with the default `GITHUB_TOKEN` do not trigger the release workflow.
+
+6. Verify the release actually shipped before calling it done: `git ls-remote --tags origin` shows the new tag, the release workflow ran green end to end (including Deploy Website), and kickstart-cli.org shows the new version. The weekly `Scheduled Evals` workflow also runs a release-drift check that fails whenever `pyproject.toml` names a version with no matching tag or GitHub Release.
 
 The release workflow builds the Python package and Python 3.14 binary archives (`kickstart-<platform>-py3.14.tar.gz` for `linux-x64`, `linux-arm64`, and `macos-arm64`), publishes or updates the GitHub Release, and deploys the website with metadata for that tag.
 
@@ -38,7 +41,9 @@ The release workflow builds the Python package and Python 3.14 binary archives (
 
 For documentation, website copy, tests, or non-behavior fixes that should stay on the current version, do not create a new version number.
 
-Retag the current release line after the fix is merged. The release workflow updates the existing GitHub Release for that tag, overwrites GitHub Release assets, and refreshes generated release notes. PyPI publish uses `--skip-existing`, so existing package artifacts for that version are skipped (no overwrite).
+Retag the current release line after the fix is merged. The release workflow updates the existing GitHub Release for that tag, overwrites GitHub Release assets, and refreshes generated release notes.
+
+Caveat: a merged-but-untagged version bump blocks same-version retags. `release-check` compares the tag against `pyproject.toml` at the tagged commit, and every commit after the bump carries the new version — so no fix can reach the published release or the website until the pending version is tagged. Tag the pending version first.
 
 ## Website
 


### PR DESCRIPTION
## Primary changes

Stacked PR 1/5 from the 2026-07-11 Linear-vs-repo audit. Kills the "green-while-skipping" failure mode that stranded v0.4.3 untagged for two weeks: `auto-tag.yml` now **fails** when `RELEASE_TAG_TOKEN` is missing (previously a `::notice` on a green run), the release website deploy fails on the canonical repo when Cloudflare credentials are absent (forks still skip), a weekly release-drift job catches strand modes that bump-time checks can't, the release verify job runs the website version-sync test **before** anything publishes, and the release docs get the corrections that would have prevented mis-tagging (explicit bump-commit sha in manual tag commands, the untagged-bump-blocks-retags caveat, the golden-fixture regeneration step).

## Reviewer walkthrough

1. `.github/workflows/auto-tag.yml` — credentials check hard-fails; header comment and dispatch warning rewritten (a dispatch tags checked-out HEAD, not the bump commit).
2. `.github/workflows/release.yml` — verify job gains Bun + `bun run check` in `website/`; website job's credential check fails on `woud420/kickstart`, skips on forks.
3. `.github/workflows/scheduled-evals.yml` — new `release-drift` job: pyproject version must have a tag, a GitHub Release, and a resolving manifest-semantics URL.
4. `docs/release-policy.md`, `.agents/skills/cut-release/SKILL.md`, `docs/contributing.md` — manual-tag sha, retag precondition, fixture-regen step, post-release verification checklist.
5. `CHANGELOG.md` — v0.4.3 entry drops the PyPI-badge claim (badge was removed in `b033d86` the day after the entry merged); header states the sync guarantee precisely.

## Correctness and invariants

The auto-tag credentials step only executes when the paths filter matched AND the tag doesn't exist, so failing it has zero false positives. Fork behavior is preserved via the `GITHUB_REPOSITORY` guard. The drift job uses only stdlib python + `gh` available on ubuntu runners. No Python source changes.

## Testing and QA

`make check` green on this branch (lint, mypy, hygiene audits, template audit, 537 passed; one pre-existing env-sensitive local failure `test_install_command_skips_path_when_already_on_path` also fails on clean `origin/master` on this Arch machine and is excluded — CI ubuntu passes it). `cd website && bun run check` green (18 tests).

## Risk / Rollout

Behavior change: a version-bump merge without the secret now fails a workflow run instead of silently skipping — that is the point; the failure email is the alarm. Merge this before tagging v0.4.3 is optional: the stranded release itself is unstuck manually per ENG-104 (`git tag -a v0.4.3 -m "Release v0.4.3" d4b301b && git push origin v0.4.3`).

Refs ENG-104
Resolves ENG-153
