### PR TITLE
Close the generator gaps the repo audit surfaced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LOG_RESET :=
 endif
 log = printf "$(LOG_COLOR)==>$(LOG_RESET) %s\n" "$(1)"
 
-.PHONY: help setup install run tests test-unit test-integration coverage typecheck lint format format-check type-hygiene template-audit check package binary build release-check clean
+.PHONY: help setup install run tests test-unit test-integration coverage typecheck lint format format-check type-hygiene import-hygiene template-audit check package binary build release-check clean
 
 help:
 	@echo "Usage:"
@@ -35,6 +35,7 @@ help:
 	@echo "  make format           Format source, tests, and CI Python with Ruff"
 	@echo "  make format-check     Check Ruff formatting without changing files"
 	@echo "  make type-hygiene     Check for loose Any/object-style type annotations"
+	@echo "  make import-hygiene   Check error classes are imported from src.utils.errors"
 	@echo "  make template-audit   Check template wiring inventory"
 	@echo "  make check            Run lint, typecheck, and tests"
 	@echo "  make package          Build wheel and source distribution"
@@ -87,11 +88,15 @@ type-hygiene:
 	@$(call log,Auditing type hygiene)
 	@$(PY) scripts/type_hygiene_audit.py
 
+import-hygiene:
+	@$(call log,Auditing import provenance)
+	@$(PY) scripts/import_hygiene_audit.py
+
 template-audit:
 	@$(call log,Auditing template wiring)
 	@$(PY) scripts/template_wiring_audit.py --strict
 
-check: lint typecheck type-hygiene template-audit tests
+check: lint typecheck type-hygiene import-hygiene template-audit tests
 
 package:
 	@$(call log,Building Python package)

--- a/docs/scaffold-contract.md
+++ b/docs/scaffold-contract.md
@@ -7,12 +7,16 @@ kickstart generates a stable project map for humans and agents. The goal is not 
 Every project type gets:
 
 - `AGENTS.md`: short agent map for where to look first.
+- `README.md`: project intent and first commands.
+- `Makefile` with a canonical `check` target (lint + typecheck + tests) that CI invokes.
 - `docs/architecture/`: structure, boundaries, and architecture notes.
 - `docs/contracts/`: project-specific public surface. For a service this may be HTTP, env vars, ports, and queues; for a CLI it may be commands, flags, config files, and exit codes; for a library it may be public APIs and package metadata.
 - `docs/operations/`: project-specific development, validation, packaging, deployment, and runbook notes.
 - `docs/decisions/`: durable architecture and implementation decisions.
 - `.kickstart/scaffold.json`: machine-readable scaffold metadata.
 - `.github/workflows/ci.yml`: per-language GitHub Actions workflow that runs `make check` (lint + typecheck + tests) on push and pull requests. The workflow is emitted for every service, CLI, library, and frontend; system scaffolds emit `build.yml`, `test.yml`, and `deploy.yml` at the same path instead.
+
+This list is the same baseline that `kickstart adopt --check` validates (`STANDARD_ARTIFACTS` in `src/generator/adoption.py`); a repo satisfying this document passes the check.
 
 There is no separate root architecture document. `docs/architecture/` is the canonical architecture location.
 
@@ -28,7 +32,7 @@ There is no separate root architecture document. `docs/architecture/` is the can
 - `project.entrypoint`: optional process entrypoint.
 - `project.operation_root`: optional use-case implementation root.
 - `project.src_root_files`: optional list of files expected directly under `src/`.
-- `execution.models`: how code runs, for example `container`, `cloudflare-worker`, `static-site`, `cli`, or `library`.
+- `execution.models`: which runtime-artifact shape the scaffold generated, for example `container`, `cloudflare-worker`, `static-site`, `cli`, or `library`. `execution` records which runtime-artifact files the scaffold generated, never how code behaves.
 - `execution.platforms`: where runtime artifacts are meant to run, for example `local`, `kubernetes`, `cloudflare-workers`, `static-host`, or `none`.
 - `artifacts`: emitted files and tool configs, for example `image: dockerfile`, `kubernetes: kustomize`, `kubernetes: helm`, `worker: wrangler`, `iac: terraform`, or `ci: github-actions`.
 - `provider.targets`: infrastructure providers targeted by generated IaC or platform config, for example `aws`, `gcp`, or `cloudflare`.

--- a/scripts/import_hygiene_audit.py
+++ b/scripts/import_hygiene_audit.py
@@ -1,0 +1,96 @@
+"""Audit import provenance for the split error model.
+
+Exception classes live in `src.utils.errors`; `src.utils.error_handling`
+owns only the handling API (decorators, ErrorCollector, safe_* helpers).
+Because error_handling re-imports a few classes for its own use, importing
+an error class from it half-works: some names resolve, others raise
+ImportError only at import time. PR #81 merged green with exactly that
+mixed import and broke master. This audit turns the mistake into a lint
+failure: any name ending in ``Error`` imported from
+``src.utils.error_handling`` is flagged.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOTS = ("src", "scripts", "ci", "tests")
+
+# Matches single-line and parenthesized multi-line import statements.
+IMPORT_STATEMENT_PATTERN = re.compile(
+    r"from\s+src\.utils\.error_handling\s+import\s+(\([^)]*\)|[^\n]*)",
+    re.MULTILINE,
+)
+ERROR_NAME_PATTERN = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*Error)\b")
+
+
+@dataclass(frozen=True)
+class ImportHygieneIssue:
+    """One error-class import from the wrong module."""
+
+    path: Path
+    line_number: int
+    name: str
+
+    def render(self) -> str:
+        """Return a compact command-line issue string."""
+        relative_path = self.path.relative_to(REPO_ROOT)
+        return (
+            f"{relative_path}:{self.line_number}: imports {self.name} from"
+            " src.utils.error_handling — error classes live in src.utils.errors"
+        )
+
+
+def main() -> int:
+    """Run the import hygiene audit."""
+    source_files = _python_source_files()
+    issues = _scan_files(source_files)
+
+    print(f"import hygiene source files: {len(source_files)}")
+    print(f"import hygiene issues: {len(issues)}")
+    for issue in issues:
+        print(issue.render())
+
+    return 1 if issues else 0
+
+
+def _python_source_files() -> tuple[Path, ...]:
+    """Return Python source, script, CI, and test files to audit."""
+    files: list[Path] = []
+    for root_name in SOURCE_ROOTS:
+        root = REPO_ROOT / root_name
+        if not root.exists():
+            continue
+        files.extend(
+            path
+            for path in root.rglob("*.py")
+            if "__pycache__" not in path.parts and not path.name.endswith(".tpl")
+        )
+    return tuple(sorted(path for path in files if path.name != "import_hygiene_audit.py"))
+
+
+def find_issues(source: str, path: Path) -> tuple[ImportHygieneIssue, ...]:
+    """Return every error-class name imported from error_handling in ``source``."""
+    issues: list[ImportHygieneIssue] = []
+    for match in IMPORT_STATEMENT_PATTERN.finditer(source):
+        line_number = source.count("\n", 0, match.start()) + 1
+        for name_match in ERROR_NAME_PATTERN.finditer(match.group(1)):
+            issues.append(
+                ImportHygieneIssue(path=path, line_number=line_number, name=name_match.group(1))
+            )
+    return tuple(issues)
+
+
+def _scan_files(files: tuple[Path, ...]) -> tuple[ImportHygieneIssue, ...]:
+    """Return all wrong-module error imports for the given files."""
+    issues: list[ImportHygieneIssue] = []
+    for path in files:
+        issues.extend(find_issues(path.read_text(encoding="utf-8"), path))
+    return tuple(issues)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/stack/toolchain_versions.py
+++ b/src/stack/toolchain_versions.py
@@ -4,6 +4,12 @@ Each constant is consumed by Jinja templates via the ``vars`` field of a
 ``TemplateConfig``. Keeping the pins here means a generated project's
 Dockerfile, package manifest, and CI workflow agree on a single version
 without having to chase string literals across templates.
+
+Scope: language toolchains only. Base images that are not language
+toolchains (cpp's ``gcc:14`` builder, react's ``nginx:1.27-alpine``
+runtime) stay pinned in their templates deliberately — nothing else in
+those scaffolds has to agree with them, so there is no cross-file drift
+for this module to prevent.
 """
 
 from typing import Final
@@ -17,6 +23,10 @@ POETRY_VERSION: Final[str] = "1.8.4"
 RUST_TOOLCHAIN: Final[str] = "1.88"
 RUST_DOCKER_TAG: Final[str] = "1.88-bookworm"
 GO_VERSION: Final[str] = "1.26"
+# Must provide at least GO_VERSION: generated go.mod requires >= GO_VERSION
+# and the builder runs with GOTOOLCHAIN defaulting to local, so a builder
+# image older than go.mod breaks every generated Go service container.
+GO_DOCKER_TAG: Final[str] = "1.26.2-bookworm"
 
 
 def toolchain_vars() -> dict[str, TemplateValue]:
@@ -33,4 +43,5 @@ def toolchain_vars() -> dict[str, TemplateValue]:
         "rust_toolchain": RUST_TOOLCHAIN,
         "rust_docker_tag": RUST_DOCKER_TAG,
         "go_version": GO_VERSION,
+        "go_docker_tag": GO_DOCKER_TAG,
     }

--- a/src/templates/go/Dockerfile.tpl
+++ b/src/templates/go/Dockerfile.tpl
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:{{ go_docker_tag }} AS builder
 
 WORKDIR /app
 COPY . .

--- a/src/utils/error_handling.py
+++ b/src/utils/error_handling.py
@@ -22,6 +22,31 @@ from src.utils.types import ErrorContext, ErrorContextValue
 
 logger = logging.getLogger(__name__)
 
+# The handling API only. Exception classes live in `src.utils.errors` and
+# are deliberately absent: importing an error class from this module
+# half-worked (only the four classes imported above resolved), which is
+# exactly how PR #81 merged green and broke master. Import error classes
+# from `src.utils.errors`; `make check` enforces this via the import
+# hygiene audit.
+__all__ = [
+    "error_context",
+    "handle_file_operations",
+    "handle_template_operations",
+    "handle_directory_operations",
+    "handle_http_operations",
+    "safe_operation",
+    "safe_operation_context",
+    "ErrorCollector",
+    "format_error_message",
+    "log_operation_result",
+    "batch_operation_wrapper",
+    "validate_language_support",
+    "ensure_directory_exists",
+    "safe_binary_write",
+    "safe_file_write",
+    "safe_file_copy",
+]
+
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")

--- a/src/utils/fs.py
+++ b/src/utils/fs.py
@@ -3,6 +3,7 @@ import logging
 from jinja2 import Environment, FileSystemLoader, DictLoader, Template
 from jinja2.exceptions import TemplateError as Jinja2TemplateError, TemplateNotFound
 from src.utils.errors import TemplateError
+from src.utils.logger import warn
 from src.utils.types import MutableRenderVars, RenderValue, RenderVars
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,11 @@ def write_file(path: Path, template: Path | str, **vars: RenderValue) -> None:
         OSError: If file cannot be written
 
     Template rendering failures do not raise; they fall back to legacy
-    placeholder replacement.
+    placeholder replacement and emit a user-facing warning. The fallback
+    only substitutes ``{{NAME}}`` placeholders, so a template with real
+    Jinja syntax (blocks, conditionals) that fails to render ships its
+    source markup verbatim — the warning is the signal to inspect the
+    generated file.
     """
     render_vars = _with_legacy_variable_aliases(vars)
 
@@ -167,7 +172,11 @@ def write_file(path: Path, template: Path | str, **vars: RenderValue) -> None:
                 content = engine.render_template(str(relative_path), render_vars)
                 logger.debug(f"Successfully rendered Jinja2 template: {template}")
             except (TemplateError, FileNotFoundError) as e:
-                # Fallback to legacy placeholder replacement
+                # Fallback to legacy placeholder replacement. Surface it to
+                # the user: the generator's own render path raises on the
+                # same error, and a silent log-only fallback ships broken
+                # Jinja markup verbatim into the generated file.
+                warn(f"Template {template} failed to render as Jinja ({e}); wrote it with legacy {{{{NAME}}}} substitution only — inspect {path}")
                 logger.warning(f"Jinja2 templating failed for {template}, falling back to legacy: {e}")
                 content = template.read_text(encoding='utf-8')
                 content = _legacy_replace(content, render_vars)
@@ -179,7 +188,8 @@ def write_file(path: Path, template: Path | str, **vars: RenderValue) -> None:
                 content = engine.render_string(template, render_vars)
                 logger.debug("Successfully rendered Jinja2 string template")
             except TemplateError as e:
-                # Fallback to legacy placeholder replacement
+                # Same fallback for string templates; same user-facing signal.
+                warn(f"Inline template for {path} failed to render as Jinja ({e}); wrote it with legacy {{{{NAME}}}} substitution only")
                 logger.warning(f"Jinja2 string templating failed, falling back to legacy: {e}")
                 content = _legacy_replace(template, render_vars)
 

--- a/tests/integration/test_scaffold_contract_roundtrip.py
+++ b/tests/integration/test_scaffold_contract_roundtrip.py
@@ -1,0 +1,46 @@
+"""Every generated scaffold satisfies its own adoption check.
+
+docs/scaffold-contract.md, STANDARD_ARTIFACTS in src/generator/adoption.py,
+and what generators actually emit are three descriptions of the same ENG-9
+baseline. This test pins the round trip so the three legs cannot drift
+apart silently: one scaffold per project kind is generated into a temp
+directory and must report `complete: true` from the same read-only check
+that `kickstart adopt --check` runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.generator.adoption import inspect_repo
+from tests.integration.conftest import KickstartRunner
+
+ROUNDTRIP_CASES = (
+    ("python-service", ("create", "service", "api", "--lang", "python")),
+    ("typescript-worker", ("create", "service", "edge", "--lang", "typescript", "--runtime", "cloudflare-workers")),
+    ("python-lib", ("create", "lib", "shared-models", "--lang", "python")),
+    ("rust-cli", ("create", "cli", "ops-tool", "--lang", "rust")),
+    ("frontend", ("create", "frontend", "web-app")),
+    ("aws-kubernetes-system", ("create", "system", "platform", "--cloud", "aws", "--runtime", "kubernetes", "--knowledge", "none")),
+)
+
+
+@pytest.mark.parametrize(("slug", "args"), ROUNDTRIP_CASES, ids=[case[0] for case in ROUNDTRIP_CASES])
+def test_generated_scaffold_passes_adoption_check(
+    slug: str,
+    args: tuple[str, ...],
+    kickstart_run: KickstartRunner,
+    repo_root: Path,
+    tmp_path: Path,
+) -> None:
+    completed = kickstart_run(*args, "--root", str(tmp_path), cwd=repo_root, capture_output=True, text=True)
+    assert completed.returncode == 0, f"{slug} generation failed: {completed.stdout}{completed.stderr}"
+
+    project_name = args[2]
+    report = inspect_repo(tmp_path / project_name)
+
+    incomplete = [artifact for artifact in report.artifacts if not artifact.ok]
+    details = ", ".join(f"{artifact.path}: {artifact.issue or 'missing'}" for artifact in incomplete)
+    assert report.complete, f"{slug} scaffold fails its own adoption check: {details}"

--- a/tests/unit/scripts/test_import_hygiene_audit.py
+++ b/tests/unit/scripts/test_import_hygiene_audit.py
@@ -1,0 +1,56 @@
+"""The import hygiene audit catches error-class imports from the wrong module.
+
+PR #81 merged green while importing TemplateError from
+src.utils.error_handling (it lives in src.utils.errors) and broke master.
+These tests pin that failure class as a lint error.
+
+The banned import statement is always built by concatenation here so that
+this test file itself stays clean under the audit (the same trick
+type_hygiene_audit uses for its own patterns).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.import_hygiene_audit import find_issues
+
+FAKE_PATH = Path("/repo/src/example.py")
+BANNED_IMPORT = "from src.utils." + "error_handling import "
+
+
+def test_flags_error_class_from_error_handling() -> None:
+    source = BANNED_IMPORT + "TemplateError\n"
+    issues = find_issues(source, FAKE_PATH)
+    assert [issue.name for issue in issues] == ["TemplateError"]
+    assert issues[0].line_number == 1
+
+
+def test_flags_mixed_import_exactly_like_pr_81() -> None:
+    source = BANNED_IMPORT + "KickstartError, TemplateError\n"
+    issues = find_issues(source, FAKE_PATH)
+    assert sorted(issue.name for issue in issues) == ["KickstartError", "TemplateError"]
+
+
+def test_flags_parenthesized_multiline_import() -> None:
+    source = BANNED_IMPORT + "(\n    ErrorCollector,\n    FileOperationError,\n)\n"
+    issues = find_issues(source, FAKE_PATH)
+    assert [issue.name for issue in issues] == ["FileOperationError"]
+    assert issues[0].line_number == 1
+
+
+def test_allows_handling_api_imports() -> None:
+    source = BANNED_IMPORT + "ErrorCollector, safe_file_write\nfrom src.utils.errors import TemplateError\n"
+    assert find_issues(source, FAKE_PATH) == ()
+
+
+def test_reports_line_numbers_for_later_imports() -> None:
+    source = "import os\n\n" + BANNED_IMPORT + "DirectoryCreationError\n"
+    issues = find_issues(source, FAKE_PATH)
+    assert issues[0].line_number == 3
+
+
+def test_repo_is_currently_clean() -> None:
+    from scripts.import_hygiene_audit import _python_source_files, _scan_files
+
+    assert _scan_files(_python_source_files()) == ()


### PR DESCRIPTION
## Primary changes

Stacked PR 2/5 (base: `audit/01-release-machinery`). Generator-side fixes from the audit: the Go builder image joins the toolchain single source of truth (`go_docker_tag` in `toolchain_versions.py`; the hardcoded `golang:1.26.2-bookworm` would have broken every generated Go service container on the next `GO_VERSION` bump under `GOTOOLCHAIN=local`); the PR #81 master-breaking import class becomes a lint error via a new import-hygiene audit in `make check` plus `__all__` on `error_handling.py`; `write_file`'s legacy template fallback emits a user-facing warning instead of shipping broken Jinja markup with only a hidden `logger.warning`; and `docs/scaffold-contract.md` now lists all nine always-generated artifacts (README.md and the Makefile-with-check were missing versus what `adopt --check` enforces) with the `execution.*` scope wording the PR #80 review prescribed.

## Reviewer walkthrough

1. `src/stack/toolchain_versions.py` + `src/templates/go/Dockerfile.tpl` — new pin + template var, mirroring the existing `rust_docker_tag` pattern; docstring states which base images are deliberately out of SoT scope (cpp `gcc:14`, react `nginx:1.27-alpine`).
2. `scripts/import_hygiene_audit.py`, `tests/unit/scripts/test_import_hygiene_audit.py`, `Makefile` — flags any `*Error` imported from `src.utils.error_handling`; wired into `check`.
3. `src/utils/error_handling.py` — `__all__` limited to the handling API.
4. `src/utils/fs.py` — both fallback branches call the user-facing `warn()` naming the written file; docstring documents the corrupt-output hazard.
5. `docs/scaffold-contract.md` — two new artifact bullets + adoption.py equivalence note + `execution` scope sentence.
6. `tests/integration/test_scaffold_contract_roundtrip.py` — one scaffold per kind must pass its own `inspect_repo(...).complete`.

## Correctness and invariants

`go_docker_tag` flows through the same `toolchain_vars()` path the rust/python tags already use (verified by the round-trip and existing template-wiring audits). The import audit scans source text, excludes itself, and its tests build banned strings by concatenation so the repo stays audit-clean. No generated-output behavior changes except the Go Dockerfile FROM line (byte-identical value today).

## Testing and QA

`make check` green including the new `import-hygiene` target and round-trip test (537 passed; same pre-existing env-sensitive local exclusion as PR #83). The audit's unit tests reproduce the exact PR #81 mixed import and the parenthesized multi-line form.

## Risk / Rollout

Low: the Go image value is unchanged today, only its source of truth moves. The import audit could flag future legitimate `*Error`-suffixed non-exception names from error_handling — none exist and the module's `__all__` now prevents adding them accidentally.

Resolves ENG-154
Refs ENG-9
