### PR TITLE
Wire the tiered eval runner into CI and close eval coverage gaps

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -33,6 +33,7 @@ current release line, or prepare a release PR. The full policy is
    make check
    cd website && bun run check && cd ..
    make release-check TAG=vX.Y.Z
+   PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier full
    ```
 
 6. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,24 +154,29 @@ jobs:
 
           test -d /tmp/test-cli-tool
 
-      # Dogfood gate: kickstart must bootstrap a kickstart-like project that
-      # passes taste rules and its own `make check`. CI runs the headline
-      # python case; the full matrix stays a local eval (docs/evals.md).
+      # Dogfood gate, tier `pr` of the eval suite: the four fast bootstrap
+      # cases (taste rules + generated `make check`) plus the scaffold-weight
+      # baseline check against tests/fixtures/scaffold-weight-baselines.json.
+      # One entrypoint so CI and local runs agree (docs/evals.md); the full
+      # matrix runs weekly in Scheduled Evals via `--tier full`.
       - name: Restore bootstrap eval dependency cache
         uses: actions/cache@v4
         with:
-          path: /tmp/bootstrap-eval-cache
+          path: /tmp/kickstart-eval-cache
           key: bootstrap-eval-${{ runner.os }}-${{ hashFiles('src/stack/toolchain_versions.py', 'src/templates/python/**') }}
           restore-keys: |
             bootstrap-eval-${{ runner.os }}-
 
-      - name: Bootstrap eval (python CLI + full-extension service, TS worker, Rust CLI)
-        run: |
-          PYTHONPATH=$(pwd) poetry run python scripts/bootstrap_eval.py \
-            --cases python-cli-kickstart-like python-service typescript-worker rust-cli \
-            --output-root /tmp/bootstrap-eval \
-            --cache-root /tmp/bootstrap-eval-cache \
-            --report /tmp/bootstrap-eval.md
+      - name: Eval suite (tier pr)
+        run: PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier pr
+
+      - name: Upload eval reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-reports-pr
+          path: /tmp/kickstart-run-evals-*.md
+          retention-days: 7
 
       - name: Smoke test kickstart install subcommand
         run: |

--- a/.github/workflows/scheduled-evals.yml
+++ b/.github/workflows/scheduled-evals.yml
@@ -3,8 +3,13 @@ name: Scheduled Evals
 # Weekly canary against live toolchains. Generated projects resolve their
 # dependencies fresh, so template rot (new ruff/mypy/clippy releases, crate
 # MSRV bumps, registry changes) surfaces here within a week even when no PR
-# touches the templates. PRs gate the fast bootstrap cases; this run covers
-# the full matrix.
+# touches the templates. PRs gate eval tier `pr` (four fast bootstrap
+# cases + weight baselines); this run covers tier `full`: the whole
+# bootstrap matrix (python cli/lib/service/service-minimal, typescript
+# worker, rust cli, cpp service), weight baselines, determinism, and the
+# website-examples drift check. Go services and frontend scaffolds are not
+# yet bootstrap-validated here — extending the matrix is tracked on the
+# board — so rot in those templates does NOT surface within a week.
 
 on:
   schedule:
@@ -35,23 +40,18 @@ jobs:
         with:
           bun-version: "1.3.5"
 
-      - name: Full bootstrap eval (all cases, live dependencies)
-        run: |
-          PYTHONPATH=$(pwd) poetry run python scripts/bootstrap_eval.py \
-            --output-root /tmp/bootstrap-eval \
-            --cache-root /tmp/bootstrap-eval-cache \
-            --report /tmp/bootstrap-eval.md
+      # Tier `full` = full bootstrap matrix + weight baselines +
+      # determinism tests + website-examples drift check, from the same
+      # entrypoint CI and local runs use.
+      - name: Eval suite (tier full)
+        run: PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier full
 
-      - name: Website examples drift check
-        run: |
-          PYTHONPATH=$(pwd) poetry run python -m pytest tests/integration/test_website_examples.py -q
-
-      - name: Upload eval report
+      - name: Upload eval reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: bootstrap-eval-report
-          path: /tmp/bootstrap-eval.md
+          name: eval-reports-full
+          path: /tmp/kickstart-run-evals-*.md
           retention-days: 30
 
   # A merged version bump whose tag never got pushed is a stranded release:

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -109,7 +109,30 @@ capability declared in `.kickstart/scaffold.json` must be exercised by at
 least one generated test (`capability-tests` rule). The eval exits non-zero
 when any case fails generation, taste, capability coverage, or `make check`.
 
-CI gates four cases on every PR (python CLI, full-extension python service,
-typescript worker, rust CLI); the `Scheduled Evals` workflow runs the full
-matrix plus the website-examples drift check weekly against live
-toolchains, so template rot surfaces within a week without slowing PRs.
+CI runs `run_evals.py --tier pr` on every PR (python CLI, full-extension
+python service, typescript worker, rust CLI, plus the weight-baseline
+check); the `Scheduled Evals` workflow runs `--tier full` weekly against
+live toolchains — the whole bootstrap matrix, weight baselines,
+determinism, and the website-examples drift check. Template rot in the
+bootstrap matrix surfaces within a week without slowing PRs. Honest
+coverage note: go services and frontend scaffolds are not yet in the
+bootstrap matrix (their generation shape and weight are guarded, their
+generated `make test` is not), so rot there does not surface weekly —
+extending the matrix is tracked on the board.
+
+## Scaffold Weight Baselines
+
+`tests/fixtures/scaffold-weight-baselines.json` pins each scaffold's file
+count and content bytes. `token_savings_eval.py --check-baselines` fails
+when a scaffold's file count changes at all or its bytes drift beyond
+±10% of the committed baseline — the regression guard for the
+token-efficiency promise, run per PR (tier `pr`) and weekly (tier `full`):
+
+```bash
+PYTHONPATH=$(pwd) poetry run python scripts/token_savings_eval.py --check-baselines
+PYTHONPATH=$(pwd) poetry run python scripts/token_savings_eval.py --update-baselines  # acknowledge deliberate changes
+```
+
+Re-baseline (`--update-baselines`) only for deliberate template changes,
+and commit the fixture diff in the same PR as the template change so the
+review sees the weight delta.

--- a/scripts/generated_make_test_eval.py
+++ b/scripts/generated_make_test_eval.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import signal
 import subprocess
+import tempfile
 import time
 from typing import Literal, cast
 
@@ -349,13 +350,14 @@ def write_report(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run make targets across generated scaffolds.")
-    parser.add_argument("--output-root", type=Path, default=Path("/private/tmp/kickstart-scaffold-matrix"))
-    parser.add_argument("--report", type=Path, default=Path("reports/generated-make-test-eval.md"))
+    scratch = Path(tempfile.gettempdir())
+    parser.add_argument("--output-root", type=Path, default=scratch / "kickstart-scaffold-matrix")
+    parser.add_argument("--report", type=Path, default=scratch / "kickstart-generated-make-test-eval.md")
     parser.add_argument("--timeout-seconds", type=int, default=35)
     parser.add_argument("--workers", type=int, default=8)
     parser.add_argument("--target", default="test")
     parser.add_argument("--dependency-mode", choices=("network", "cached", "offline"), default="cached")
-    parser.add_argument("--cache-root", type=Path, default=Path("/private/tmp/kickstart-eval-cache"))
+    parser.add_argument("--cache-root", type=Path, default=scratch / "kickstart-eval-cache")
     parser.add_argument("--prewarm", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--prewarm-workers", type=int, default=2)
     args = parser.parse_args()

--- a/scripts/scaffold_matrix_eval.py
+++ b/scripts/scaffold_matrix_eval.py
@@ -15,6 +15,7 @@ import random
 import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Literal, TypeGuard, cast
 
 
@@ -831,8 +832,9 @@ def main() -> int:
     parser.add_argument("--max-components-per-project", type=int, default=9)
     parser.add_argument("--max-system-depth", type=int, default=1)
     parser.add_argument("--exclude-known-gaps", action="store_true")
-    parser.add_argument("--output-root", type=Path, default=Path("/private/tmp/kickstart-scaffold-matrix"))
-    parser.add_argument("--report", type=Path, default=Path("reports/scaffold-eval-120.md"))
+    scratch = Path(tempfile.gettempdir())
+    parser.add_argument("--output-root", type=Path, default=scratch / "kickstart-scaffold-matrix")
+    parser.add_argument("--report", type=Path, default=scratch / "kickstart-scaffold-eval-120.md")
     args = parser.parse_args()
 
     if args.max_components_per_project < 1:

--- a/scripts/token_savings_eval.py
+++ b/scripts/token_savings_eval.py
@@ -127,6 +127,22 @@ DEFAULT_CASES: tuple[ScaffoldCase, ...] = (
             "none",
         ),
     ),
+    ScaffoldCase(
+        slug="python-cli",
+        args=("create", "cli", "ops-cli", "--lang", "python"),
+    ),
+    ScaffoldCase(
+        slug="go-service",
+        args=("create", "service", "api-go", "--lang", "go"),
+    ),
+    ScaffoldCase(
+        slug="cpp-service",
+        args=("create", "service", "api-cpp", "--lang", "cpp"),
+    ),
+    ScaffoldCase(
+        slug="frontend",
+        args=("create", "frontend", "web-app"),
+    ),
 )
 
 

--- a/tests/fixtures/scaffold-weight-baselines.json
+++ b/tests/fixtures/scaffold-weight-baselines.json
@@ -3,6 +3,22 @@
     "content_bytes": 23323,
     "files": 41
   },
+  "cpp-service": {
+    "content_bytes": 6635,
+    "files": 16
+  },
+  "frontend": {
+    "content_bytes": 8704,
+    "files": 21
+  },
+  "go-service": {
+    "content_bytes": 6368,
+    "files": 21
+  },
+  "python-cli": {
+    "content_bytes": 11057,
+    "files": 25
+  },
   "python-lib": {
     "content_bytes": 6897,
     "files": 13

--- a/tests/unit/scripts/test_token_savings_eval.py
+++ b/tests/unit/scripts/test_token_savings_eval.py
@@ -144,3 +144,13 @@ def test_baselines_payload_round_trips_through_compare() -> None:
 def test_load_baselines_requires_existing_file(tmp_path: Path) -> None:
     with pytest.raises(BaselineError, match="missing; run with --update-baselines"):
         load_baselines(tmp_path / "absent.json")
+
+
+def test_every_default_case_has_a_committed_baseline() -> None:
+    """New weight-eval cases cannot land unguarded: the committed baseline
+    file must cover exactly the DEFAULT_CASES slugs (audit finding: the
+    python CLI flagship was measured but never baseline-guarded)."""
+    from scripts.token_savings_eval import BASELINES_PATH
+
+    baselines = json.loads(BASELINES_PATH.read_text(encoding="utf-8"))
+    assert sorted(baselines) == sorted(case.slug for case in DEFAULT_CASES)


### PR DESCRIPTION
## Primary changes

Stacked PR 3/5 (base: `audit/02-generator-fixes`). The scaffold-weight regression gate built for ENG-106 ran in no automated pipeline — CI called `bootstrap_eval.py` directly with no baseline step, the weekly run skipped baselines and determinism, and nothing invoked `run_evals.py`. The soak precondition is met (weekly green since 2026-06-29), so: per-PR CI now runs `run_evals.py --tier pr`, the weekly workflow runs `--tier full`, tier reports upload as artifacts, weight baselines grow from 5 to 9 scaffolds (python-cli — the flagship — go-service, cpp-service, frontend), a unit test forbids unguarded future cases, the two older eval scripts lose their macOS-only `/private/tmp` defaults, and docs state the honest weekly-coverage story instead of "template rot surfaces within a week".

## Reviewer walkthrough

1. `.github/workflows/ci.yml` — eval step swap + failure-artifact upload; cache path follows the runner's tempdir convention.
2. `.github/workflows/scheduled-evals.yml` — `--tier full` swap; header names the real covered matrix and the go/frontend gap (tracked in ENG-156).
3. `scripts/token_savings_eval.py` + `tests/fixtures/scaffold-weight-baselines.json` — four new cases, regenerated baselines; `tests/unit/scripts/test_token_savings_eval.py` gains the exact-coverage test.
4. `scripts/scaffold_matrix_eval.py`, `scripts/generated_make_test_eval.py` — `tempfile.gettempdir()` defaults.
5. `docs/evals.md` — new Scaffold Weight Baselines section; tier-wiring claims now literally true. `cut-release` skill adds `--tier full` to pre-tag verification.

## Correctness and invariants

Tier `pr` runs the same four bootstrap cases CI ran before plus the baseline check, so CI coverage strictly grows. The weight eval only generates and counts bytes (no builds), so the four new cases need no extra toolchains anywhere. Baselines were regenerated once (`--update-baselines`) and verified (`--check-baselines` exit 0).

## Testing and QA

`--check-baselines` exit 0 with the 9-slug fixture; full suite green (537 passed, same env-sensitive exclusion); static checks + both hygiene audits green.

## Risk / Rollout

Per-PR CI time grows by the baseline check (~seconds; generation only). If a template change legitimately shifts weight, the failing eval names the scaffold and the fix is `--update-baselines` in the same PR — documented in docs/evals.md.

Resolves ENG-155
Refs ENG-106
Refs ENG-156
