### PR TITLE
Website: observable deploys, one version source, security.txt fix

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -19,15 +19,12 @@ current release line, or prepare a release PR. The full policy is
 2. Add the release entry to `CHANGELOG.md` and to `releaseNotes` in
    `website/src/site/content.ts`, and bump `defaultProjectMeta.latestVersion`
    there. Website tests fail when the current version has no release note.
-3. Update the dev-vars fallback in `website/wrangler.toml`
-   (`PROJECT_VERSION`, `RELEASE_URL`) and the `defaultConfig` fallback in
-   `website/scripts/render-release-config.ts`.
-4. Regenerate the committed golden fixture (procedure in
+3. Regenerate the committed golden fixture (procedure in
    `docs/contributing.md`). The version bump changes the `semantics` URL
    inside the fixture's `.kickstart/scaffold.json`, so `make check` fails
    with a golden-fixture diff until the fixture is regenerated — this is
    expected, not a template bug.
-5. Verify everything locally:
+4. Verify everything locally:
 
    ```bash
    make check
@@ -36,7 +33,7 @@ current release line, or prepare a release PR. The full policy is
    PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier full
    ```
 
-6. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit
+5. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit
    automatically when the `RELEASE_TAG_TOKEN` secret is configured (it
    re-runs `make release-check` first and never moves an existing tag).
    Without the secret the workflow fails — tag and push manually, pointing
@@ -48,11 +45,12 @@ current release line, or prepare a release PR. The full policy is
    git push origin vX.Y.Z
    ```
 
-7. Watch the release workflow: verify (incl. the website version-sync
+6. Watch the release workflow: verify (incl. the website version-sync
    gate) → package → binary (linux-x64, linux-arm64, macos-arm64 at
-   py3.14) → GitHub Release → website deploy. All jobs must be green,
-   including Deploy Website.
-8. Confirm the release is not stranded before reporting done:
+   py3.14) → GitHub Release → website deploy (which asserts the deployed
+   /healthz version equals the tag). All jobs must be green, including
+   Deploy Website.
+7. Confirm the release is not stranded before reporting done:
    `git ls-remote --tags origin` lists `vX.Y.Z`, the GitHub Release for
    the tag exists, and https://kickstart-cli.org shows the new version.
    A merged bump with no tag blocks all same-version retags until fixed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,3 +282,22 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WEBSITE_API_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: bun run deploy:release
+
+      # Deployed-vs-source parity is otherwise unobservable: the site can
+      # serve a stale version for weeks with every check green. /healthz
+      # reports the served version; assert it matches the tag we released.
+      - name: Verify the deployed website serves this release
+        if: ${{ steps.website-deploy.outputs.ready == 'true' }}
+        run: |
+          EXPECTED="${GITHUB_REF_NAME#v}"
+          for attempt in 1 2 3 4 5; do
+            DEPLOYED=$(curl -fsSL https://kickstart-cli.org/healthz | python3 -c "import json,sys; print(json.load(sys.stdin).get('version',''))" || true)
+            if [ "$DEPLOYED" = "$EXPECTED" ]; then
+              echo "kickstart-cli.org serves v${DEPLOYED}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: deployed version '${DEPLOYED}' != '${EXPECTED}'; retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::kickstart-cli.org still serves '${DEPLOYED}' instead of '${EXPECTED}' after deploy."
+          exit 1

--- a/website/alchemy.run.ts
+++ b/website/alchemy.run.ts
@@ -65,6 +65,20 @@ if (app.stage === "prod" && config.domain !== "") {
   });
 }
 
+// Deploying a site whose hero and release-notes links point at a
+// nonexistent GitHub release publishes 404s (exactly the stranded-v0.4.3
+// failure mode). Make "the release URL resolves" a deploy precondition
+// instead of a timing coincidence.
+if (app.stage === "prod") {
+  const releaseCheck = await fetch(config.releaseUrl, { method: "HEAD", redirect: "follow" });
+  if (!releaseCheck.ok) {
+    throw new Error(
+      `release URL does not resolve (HTTP ${releaseCheck.status}): ${config.releaseUrl} — ` +
+        "publish the release (tag + release workflow) before deploying the website.",
+    );
+  }
+}
+
 export const worker = await Worker("website", {
   name: workerName,
   entrypoint: "./src/index.ts",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,5 @@
 {
   "name": "kickstart-website",
-  "version": "0.4.2",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.5",

--- a/website/scripts/render-release-config.ts
+++ b/website/scripts/render-release-config.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 
+import { defaultProjectMeta } from "../src/site/content";
+
 interface ReleaseConfig {
   domain: string;
   output: string;
@@ -10,14 +12,17 @@ interface ReleaseConfig {
   version: string;
 }
 
-const defaultConfig: ReleaseConfig = {
+// No version or releaseUrl fallback literals here: the version comes from
+// --version, pyproject.toml, or GITHUB_REF_NAME, and resolution fails
+// loudly instead of silently deploying a stale hardcoded release. The
+// remaining defaults come from content.ts (the test-enforced source of
+// truth) or are deploy plumbing with no release-time meaning.
+const defaultConfig = {
   domain: "kickstart-cli.org",
   output: "wrangler.release.toml",
-  releaseUrl: "https://github.com/woud420/kickstart/releases/tag/v0.4.3",
-  repositoryUrl: "https://github.com/woud420/kickstart",
+  repositoryUrl: defaultProjectMeta.repositoryUrl,
   serviceName: "kickstart-site",
-  supportedFrom: "0.4.0",
-  version: "0.4.3",
+  supportedFrom: defaultProjectMeta.supportedFrom,
 };
 
 function argumentValue(args: string[], name: string): string | undefined {
@@ -65,9 +70,14 @@ export function resolveReleaseConfig(
   const repositoryUrl =
     argumentValue(args, "--repository-url") ?? repositoryUrlFromEnv(env) ?? defaultConfig.repositoryUrl;
   const versionFile = argumentValue(args, "--version-file") ?? "../pyproject.toml";
-  const version = trimVersionPrefix(
-    argumentValue(args, "--version") ?? versionFromPyproject(versionFile) ?? env.GITHUB_REF_NAME ?? defaultConfig.version,
-  );
+  const resolvedVersion =
+    argumentValue(args, "--version") ?? versionFromPyproject(versionFile) ?? env.GITHUB_REF_NAME;
+  if (resolvedVersion === undefined) {
+    throw new Error(
+      `cannot resolve the release version: pass --version, make ${versionFile} readable, or set GITHUB_REF_NAME`,
+    );
+  }
+  const version = trimVersionPrefix(resolvedVersion);
   const releaseUrl =
     argumentValue(args, "--release-url") ?? `${repositoryUrl}/releases/tag/v${version}`;
 

--- a/website/src/index.ts
+++ b/website/src/index.ts
@@ -13,7 +13,7 @@ interface Env {
 
 const PUBLIC_HOSTNAME = "kickstart-cli.org";
 const HSTS_HEADER_VALUE = "max-age=15552000";
-const SECURITY_TXT = `Contact: mailto:jm@polarcoordinates.org
+const SECURITY_TXT = `Contact: mailto:jim@polarcoordinates.org
 Expires: 2027-06-26T00:00:00Z
 Preferred-Languages: en
 Canonical: https://${PUBLIC_HOSTNAME}/.well-known/security.txt
@@ -111,7 +111,10 @@ export default {
     }
 
     if (url.pathname === "/healthz") {
-      return withSecurityHeaders(jsonResponse({ status: "ok", service }), url);
+      // Version in the health payload makes deployed-vs-source drift
+      // observable: the release pipeline asserts this equals the tag.
+      const version = stripVersionPrefix(env.PROJECT_VERSION ?? defaultProjectMeta.latestVersion);
+      return withSecurityHeaders(jsonResponse({ status: "ok", service, version }), url);
     }
 
     if (url.pathname === "/assets/site.css") {

--- a/website/tests/worker.test.ts
+++ b/website/tests/worker.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from "vitest";
 
 import worker from "../src/index";
+import { defaultProjectMeta } from "../src/site/content";
 
 const defaultEnv = {
   SERVICE_NAME: "kickstart-site",
 };
 
+// The current version comes from content.ts (itself test-pinned to
+// pyproject.toml), so a release bump updates these assertions for free
+// instead of requiring four hand-edited version strings.
+const latestVersion = defaultProjectMeta.latestVersion;
+
 describe("kickstart website worker", () => {
-  it("returns health status", async () => {
+  it("returns health status with the served version", async () => {
     const request = new Request("https://example.test/healthz") as Parameters<typeof worker.fetch>[0];
 
     const response = await worker.fetch(request, defaultEnv);
@@ -16,6 +22,19 @@ describe("kickstart website worker", () => {
     expect(await response.json()).toEqual({
       status: "ok",
       service: "kickstart-site",
+      version: latestVersion,
+    });
+  });
+
+  it("reports the deployed version from Worker vars in /healthz", async () => {
+    const request = new Request("https://example.test/healthz") as Parameters<typeof worker.fetch>[0];
+
+    const response = await worker.fetch(request, { ...defaultEnv, PROJECT_VERSION: "v9.9.9" });
+
+    expect(await response.json()).toEqual({
+      status: "ok",
+      service: "kickstart-site",
+      version: "9.9.9",
     });
   });
 
@@ -52,7 +71,7 @@ describe("kickstart website worker", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/plain");
-    expect(body).toContain("Contact: mailto:jm@polarcoordinates.org");
+    expect(body).toContain("Contact: mailto:jim@polarcoordinates.org");
     expect(body).toContain("Canonical: https://kickstart-cli.org/.well-known/security.txt");
   });
 
@@ -66,9 +85,9 @@ describe("kickstart website worker", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
     const html = await response.text();
     expect(html).toContain('<h1 id="hero-title">kickstart</h1>');
-    expect(html).toContain("/assets/site.css?v=0.4.3");
-    expect(html).toContain("/assets/site.js?v=0.4.3");
-    expect(html).toContain("v0.4.3");
+    expect(html).toContain(`/assets/site.css?v=${latestVersion}`);
+    expect(html).toContain(`/assets/site.js?v=${latestVersion}`);
+    expect(html).toContain(`v${latestVersion}`);
     expect(html).toContain("Sandbox bootstrap, tiered eval runner, coverage and badges");
     expect(html).toContain("Scaffold contract convergence");
   });
@@ -131,7 +150,7 @@ describe("kickstart website worker", () => {
   });
 
   it("serves script assets", async () => {
-    const request = new Request("https://example.test/assets/site.js?v=0.4.3") as Parameters<typeof worker.fetch>[0];
+    const request = new Request(`https://example.test/assets/site.js?v=${latestVersion}`) as Parameters<typeof worker.fetch>[0];
 
     const response = await worker.fetch(request, defaultEnv);
     const script = await response.text();

--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -2,9 +2,8 @@ name = "kickstart-site"
 main = "src/index.ts"
 compatibility_date = "2026-05-02"
 
-[vars]
-SERVICE_NAME = "kickstart-site"
-PROJECT_VERSION = "0.4.3"
-SUPPORTED_FROM_VERSION = "0.4.0"
-REPOSITORY_URL = "https://github.com/woud420/kickstart"
-RELEASE_URL = "https://github.com/woud420/kickstart/releases/tag/v0.4.3"
+# No [vars] block on purpose: release deploys render wrangler.release.toml
+# from pyproject.toml (scripts/render-release-config.ts), and local dev
+# falls back to defaultProjectMeta in src/site/content.ts, which is
+# test-pinned to pyproject.toml. A hand-maintained copy here was one more
+# version string that could (and did) go stale.


### PR DESCRIPTION
## Primary changes

Stacked PR 4/5 (base: `audit/03-eval-wiring`). The deployed site served v0.4.2 for two weeks while source said 0.4.3 and nothing could notice. Now: `/healthz` reports the served version and the release workflow asserts deployed == tag after deploy; `alchemy.run.ts` refuses a prod deploy whose release URL 404s (deploying from master during the stranded window would have published dead hero/release links); the release version collapses to one source of truth (content.ts, test-pinned to pyproject) — `worker.test.ts` derives its version assertions instead of four hand-edited strings, `render-release-config.ts` fails loudly instead of falling back to hardcoded literals, `wrangler.toml` drops its `[vars]` copy, `package.json` drops its version field (it was already a release behind — proof the copies drift). `security.txt` contact fixed `jm@` → `jim@polarcoordinates.org`.

## Reviewer walkthrough

1. `website/src/index.ts` — healthz version + security.txt contact.
2. `website/tests/worker.test.ts` — version assertions derived from `defaultProjectMeta.latestVersion`; new Worker-vars healthz test.
3. `website/scripts/render-release-config.ts` — no version/releaseUrl literals; throws when version unresolvable; remaining defaults come from content.ts.
4. `website/alchemy.run.ts` — prod-stage HEAD preflight on `config.releaseUrl`.
5. `.github/workflows/release.yml` — post-deploy `/healthz` version assertion with retries.
6. `website/wrangler.toml`, `website/package.json`, cut-release skill step removal.

## Correctness and invariants

Local dev without Worker vars falls back to content.ts, which the content test pins to pyproject — so every remaining version surface traces to `pyproject.toml`. The preflight only runs for `--stage prod`. The post-deploy check retries 5×15s to absorb propagation delay and only runs when the deploy ran.

## Testing and QA

`cd website && bun run check` green: typecheck + 18 vitest tests (was 17; +2 healthz, −1 merged). Full Python suite unaffected (no `src/` changes in this PR) — stack-tip run green.

## Risk / Rollout

If jm@polarcoordinates.org was a deliberate alias rather than a typo, revert the two-line contact change — every other identity signal (commits, account email) says jim@. The releaseUrl preflight means a manual prod deploy now requires the GitHub release to exist first; that ordering is exactly the invariant we want.

Resolves ENG-157
Refs ENG-153
