### PR TITLE
Stop pointing users at someone else's PyPI package

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -71,8 +71,11 @@ the pending version first.
 - Stable semver tags only (`vX.Y.Z`). Release candidates and build suffixes
   are rejected by CI.
 - Only tag commits already merged to `master`; the workflow enforces this.
-- PyPI artifacts are immutable. If a bad version shipped, fix forward with a
-  new patch version instead of retagging it.
+- There is no PyPI publish: the name `kickstart` on PyPI belongs to an
+  unrelated, abandoned project. The wheel/sdist attach to the GitHub
+  Release. Never document `pip install kickstart`.
+- If a bad version shipped, fix forward with a new patch version instead
+  of retagging it.
 - Do not start the tag step until `make release-check` passes locally.
 
 ## Report Back

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,8 @@ jobs:
           # macos-x64 is intentionally omitted: the macos-15-intel runner
           # schedules on arm64 hardware in this org, so PyInstaller fails with
           # IncompatibleBinaryArchError. This matches the release matrix, which
-          # dropped macos-x64 in v0.4.1 (PR #66); x64 macOS installs via PyPI.
+          # dropped macos-x64 in v0.4.1 (PR #66); x64 macOS installs from
+          # source or the release wheel (docs/install-binaries.md).
           - runner: macos-15
             platform: macos-arm64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,15 @@ jobs:
           bun install --frozen-lockfile
           bun run check
 
+  # No PyPI publish on purpose: the PyPI name "kickstart" belongs to an
+  # unrelated, abandoned 2011 project, so a publish step could only fail
+  # or mislead. The wheel/sdist attach to the GitHub Release instead. If
+  # the project ever gets a PyPI identity (rename or PEP 541 transfer),
+  # reintroduce publishing as a fail-loud step, not a skip-on-missing-token.
   package:
     name: Build Python Package
     runs-on: ubuntu-latest
     needs: verify
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout code
@@ -81,17 +84,6 @@ jobs:
 
       - name: Build package
         run: make package
-
-      - name: Publish to PyPI
-        if: ${{ !contains(github.ref_name, 'rc') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'alpha') }}
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          if [ -n "$POETRY_PYPI_TOKEN_PYPI" ]; then
-            poetry publish --no-interaction --skip-existing
-          else
-            echo "PYPI_API_TOKEN not set, skipping PyPI publish"
-          fi
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -205,15 +197,18 @@ jobs:
 
             The script downloads the matching binary archive, verifies its SHA-256, installs the binary payload under a stable directory, and exposes `kickstart` on `PATH`.
 
-            ### From PyPI
+            ### From source or wheel (platforms without a binary archive)
+
+            Do **not** `pip install kickstart` — that PyPI name belongs to an unrelated, abandoned 2011 project. Install from source, or from the wheel attached to this release:
 
             ```bash
-            pip install kickstart
+            pipx install git+https://github.com/${{ github.repository }}
+            pip install ./kickstart-*-py3-none-any.whl
             ```
 
             ### Manual binary install
 
-            Binary archives are attached for `linux-x64`, `linux-arm64`, and `macos-arm64` (Python 3.14). Other platforms install from PyPI. Pick the asset for your platform, extract it, and run `kickstart install` to place the binary payload in a user-writable directory and configure `PATH`:
+            Binary archives are attached for `linux-x64`, `linux-arm64`, and `macos-arm64` (Python 3.14). Pick the asset for your platform, extract it, and run `kickstart install` to place the binary payload in a user-writable directory and configure `PATH`:
 
             ```bash
             curl -L -o kickstart-linux-x64-py3.14.tar.gz "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/kickstart-linux-x64-py3.14.tar.gz"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Release history lives in [CHANGELOG.md](CHANGELOG.md) and on [kickstart-cli.org]
 
 ## Install
 
-One-line install of the latest release. Drops a launcher in `~/.local/bin/kickstart` and the binary payload in `~/.local/share/kickstart` (Linux x64/arm64 and macOS arm64; other platforms install from PyPI with `pip install kickstart`):
+One-line install of the latest release. Drops a launcher in `~/.local/bin/kickstart` and the binary payload in `~/.local/share/kickstart` (Linux x64/arm64 and macOS arm64; other platforms install from source, below):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/woud420/kickstart/master/scripts/install.sh | bash
@@ -56,10 +56,11 @@ Refresh in place against the newest release once installed:
 kickstart upgrade
 ```
 
-Or install from PyPI when published:
+On platforms without a binary archive (for example Intel macOS), install from source or from the wheel attached to each GitHub Release. Do **not** `pip install kickstart` — that PyPI name belongs to an unrelated, abandoned 2011 project:
 
 ```bash
-pip install kickstart
+pipx install git+https://github.com/woud420/kickstart          # from source
+pip install ./kickstart-<version>-py3-none-any.whl             # wheel from the Releases page
 ```
 
 ## Get Started
@@ -167,6 +168,6 @@ make package
 make binary
 ```
 
-kickstart supports Python `>=3.12,<3.15`. CI tests Python 3.12, 3.13, and 3.14 on Linux and macOS. Release builds attach Linux/macOS x64 and arm64 binary archives (`kickstart-<platform>-py<minor>.tar.gz`) for each supported Python minor.
+kickstart supports Python `>=3.12,<3.15`. CI tests Python 3.12, 3.13, and 3.14 on Linux and macOS. Release builds attach Python 3.14 binary archives (`kickstart-<platform>-py3.14.tar.gz`) for `linux-x64`, `linux-arm64`, and `macos-arm64`; other platforms use the source/wheel install path in [Install](#install).
 
 Current local eval evidence is tracked in [Local Evals](docs/evals.md). Reports are generated under `/tmp` or another scratch path and are not committed.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,7 @@ make check
 ```
 
 Use `make package` to build the wheel/source distribution and `make binary` to build the local kickstart binary (a PyInstaller `--onedir` payload under `dist/kickstart/`).
-GitHub Actions tests Python 3.12, 3.13, and 3.14 on Linux and macOS, then release builds attach Python 3.14 binary archives (`kickstart-<platform>-py3.14.tar.gz`) for `linux-x64`, `linux-arm64`, and `macos-arm64`. Other platforms install from PyPI.
+GitHub Actions tests Python 3.12, 3.13, and 3.14 on Linux and macOS, then release builds attach Python 3.14 binary archives (`kickstart-<platform>-py3.14.tar.gz`) for `linux-x64`, `linux-arm64`, and `macos-arm64`. Other platforms install from source or from the wheel attached to each GitHub Release (see docs/install-binaries.md).
 
 ## Releases
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,5 +4,7 @@ This directory records durable project decisions for kickstart itself.
 
 - [CLI Framework Research](cli-framework-research.md): sourced recommendation for Rust, Python, and TypeScript CLI framework defaults.
 - [Kickstart Token Savings Evidence](kickstart-token-savings-evidence.md): measured determinism and token savings for scaffold generation.
+- [Headroom Benchmark Learnings](headroom-benchmark-learnings.md): adopt/defer reasoning behind the scaffold-weight baselines and the tiered eval runner.
+- [Scaffold Metadata Architecture Review](scaffold-metadata-architecture-review.md): drift-as-reconciliation review of scaffold.json; schema 4.0 roadmap and migration ordering.
 
 Use this directory for decisions that should survive beyond a single implementation PR.

--- a/docs/install-binaries.md
+++ b/docs/install-binaries.md
@@ -7,7 +7,10 @@ Release tags publish a prebuilt kickstart binary as a `.tar.gz` archive for:
 - `macos-arm64`
 
 Each platform is built for Python `3.14`. Platforms outside this matrix
-(for example Intel macOS) install from PyPI with `pip install kickstart`.
+(for example Intel macOS) install from source
+(`pipx install git+https://github.com/woud420/kickstart`) or from the
+wheel attached to each GitHub Release. Do not `pip install kickstart`:
+the PyPI name belongs to an unrelated, abandoned 2011 project.
 
 ## Asset Names
 


### PR DESCRIPTION
## Primary changes

Stacked PR 5/5 (base: `audit/04-website-fixes`). `pip install kickstart` installs an unrelated, abandoned 2011 package (the PyPI name is owned by another author; this repo has never published there — the publish step silently skipped on every release). The command was nonetheless documented in five places and rendered into every published GitHub Release body, and since macos-x64 was dropped in v0.4.1, Intel macOS had no working documented install path. This PR strips every such claim, routes non-binary platforms to `pipx install git+…` or the wheel attached to each release, deletes the fail-soft publish step (with a comment on how to reintroduce it fail-loud if the project ever gets a PyPI identity), fixes README's pre-v0.4.1 binary-matrix description, and completes the docs/decisions index (2 of 4 records were unlisted, including the load-bearing PR #80 review).

## Reviewer walkthrough

1. `.github/workflows/release.yml` — publish step removed; release-notes template's "From PyPI" section replaced with source/wheel instructions and the explicit squatted-name warning.
2. `README.md` — Install section fallback + Development binary-matrix sentence (was "Linux/macOS x64 and arm64 for each supported Python minor"; reality is 3 targets × py3.14 since v0.4.1).
3. `docs/install-binaries.md`, `docs/contributing.md`, `.github/workflows/ci.yml` matrix comment — same correction.
4. `.agents/skills/cut-release/SKILL.md` — rule: never document `pip install kickstart`.
5. `docs/decisions/README.md` — index the headroom-benchmark and scaffold-metadata-review records.

## Correctness and invariants

No workflow behavior depends on the removed publish step (it has never successfully run). The `id-token: write` permission on the package job is removed with it. The naming decision itself (rename vs PEP 541 vs GitHub-only) is deliberately NOT made here — it's tracked in ENG-158.

## Testing and QA

Stack-tip validation green: `make lint typecheck type-hygiene import-hygiene template-audit`, full pytest (537 passed, one pre-existing env-sensitive local exclusion), `bun run check` (18 tests). Repo-wide grep confirms no remaining `pip install kickstart` guidance outside explicit do-not warnings.

## Risk / Rollout

After merge, the live v0.4.2 release body still carries the old template text; it needs a one-time `gh release edit` (tracked in ENG-158). Docs-only otherwise.

Refs ENG-158
Refs ENG-10
