### PR TITLE
Add read-only `kickstart plan` for managed docs drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ Purpose: kickstart generates deterministic starter repos for humans and coding a
 - Generator specs: `src/generator/specs.py`
 - Directory plans: `src/generator/layouts.py`
 - Managed docs projections: `src/generator/projections.py`
+- Ownership fences: `src/generator/markers.py`
+- Docs drift plan: `src/generator/docs_plan.py`
 - Template plans: `src/generator/template_plans.py`
 - Language setup plans: `src/generator/language_setup.py`
 - Scaffold metadata: `src/generator/scaffold_contract.py`

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -45,6 +45,11 @@ gaps for repos kickstart did not create (read-only; exit 0 complete / 1
 gaps / 2 usage error). Generated projects verify themselves with
 `make check`; the success output names it.
 
+Docs drift: `kickstart plan REPO --json` re-renders the managed docs
+projections from `.kickstart/scaffold.json` and reports per-artifact status
+(read-only; exit 0 in sync / 1 findings / 2 usage error). Scope contract:
+`docs/contracts/plan-drift-scope.md`.
+
 ## Source Of Truth
 
 - Public API: `src/api.py`

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -5,6 +5,7 @@ This directory collects public and generated contract documentation for the kick
 Current contract references:
 
 - [Scaffold Contract](../scaffold-contract.md): baseline generated files, metadata keys, and option vocabulary.
+- [Plan Command Drift Scope](plan-drift-scope.md): what `kickstart plan` covers, defers, and emits.
 - [Install Binaries](../install-binaries.md): release asset names and install commands.
 - [Human Guide](../human-guide.md): supported project kinds, languages, runtimes, and CLI options.
 

--- a/docs/contracts/plan-drift-scope.md
+++ b/docs/contracts/plan-drift-scope.md
@@ -1,0 +1,44 @@
+# Plan Command Drift Scope
+
+Checked: 2026-07-15
+
+`kickstart plan REPO [--json]` is the read-only docs-drift frontend. This
+contract pins what it covers, what it deliberately defers, and its output
+shape, so the broader drift work builds on it instead of forking it.
+
+## Covered
+
+Exactly the registry-rendered markdown projections
+(`src/generator/projections.py`) inside their ownership fences: `AGENTS.md`
+and the `docs/{contracts,operations,decisions}` READMEs, re-rendered from
+`.kickstart/scaffold.json` via `ScaffoldContract.from_manifest` and compared
+byte-for-byte against the fenced region on disk. The architecture README is
+presence-checked only: its content needs generation-time inputs (title,
+directory list) a schema-3.0 manifest does not record.
+
+Statuses: `in-sync`, `presence-only` (both clean); `would-create`,
+`content-drift` (unified diff attached), `unfenced` (pre-fence scaffold or
+hand-written file — a structural fact, content never compared),
+`malformed-markers`, `unreadable` (all findings).
+
+A worker-kind manifest cannot say which language generated it (the schema-3.0
+gap ENG-159 closes with `project.language`), so worker repos match either the
+TypeScript worker docs profile or the default profile.
+
+## Deferred — and to whom
+
+- Full managed-envelope drift (Makefile targets, CI workflows, artifact
+  files) and drift classes for co-owned files: the drift check built on
+  schema 4.0 (ENG-12 on ENG-159). `plan` is its docs-projection library
+  sibling (`src/generator/docs_plan.py`, alongside `adoption.py`), not a fork.
+- Inserting fences or the manifest into pre-fence repos: the adopt write path
+  (ENG-11). `plan` never writes.
+- Recovering the projection profile and architecture render inputs from the
+  manifest: the render-inputs work in the metadata review roadmap (§6 step 1).
+
+## Exit codes and JSON
+
+Exit 0 = every entry clean; 1 = at least one finding; 2 = usage error (no
+repository, or no plannable manifest). `--json` emits
+`{"root", "in_sync", "entries": [{"artifact", "target", "status", "detail",
+"diff", "profile"}]}` — the `adopt --check` report pattern.

--- a/docs/scaffold-contract.md
+++ b/docs/scaffold-contract.md
@@ -10,7 +10,7 @@ The standard interface a generated (or adopted) repository exposes is the vendor
 
 ## Managed Regions
 
-Generated managed docs (`AGENTS.md` and the `docs/` READMEs) are wrapped in ownership fences — `<!-- kickstart:begin <artifact-id> -->` / `<!-- kickstart:end <artifact-id> -->` comment markers, invisible in rendered markdown. kickstart only ever writes inside its own fences: the fenced block is whole-block replaced when the standard changes, so do not edit inside it; everything outside a fence is user-owned and never read or rewritten. Rationale and the MDX caveat: [Docs Ownership Fences](decisions/docs-ownership-fences.md).
+Generated managed docs (`AGENTS.md` and the `docs/` READMEs) are wrapped in ownership fences — `<!-- kickstart:begin <artifact-id> -->` / `<!-- kickstart:end <artifact-id> -->` comment markers, invisible in rendered markdown. kickstart only ever writes inside its own fences: the fenced block is whole-block replaced when the standard changes, so do not edit inside it; everything outside a fence is user-owned and never read or rewritten. `kickstart plan` verifies the fenced regions against the current standard, read-only ([scope contract](contracts/plan-drift-scope.md)). Rationale and the MDX caveat: [Docs Ownership Fences](decisions/docs-ownership-fences.md).
 
 ## Always Generated
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -23,6 +23,7 @@ from src.api import (
 )
 from src.cli.dispatch import ProjectCreators, dispatch_project_creation
 from src.generator.adoption import AdoptionTargetError, inspect_repo
+from src.generator.docs_plan import DocsPlanTargetError, inspect_docs
 from src.cli.options import CreateCommandOptions, CreateOptions, ResolvedCreateArgs
 from src.cli.prompts import ConfirmReader, PromptReader, prompt_for_missing_args
 from src.utils.errors import KickstartError
@@ -81,6 +82,42 @@ def version() -> None:
 def upgrade() -> None:
     """Upgrade to the latest version."""
     check_for_update()
+
+
+@app.command()
+def plan(
+    path: Path = typer.Argument(Path("."), help="Repository to inspect"),
+    json_output: bool = typer.Option(False, "--json", help="Emit a machine-readable report"),
+) -> None:
+    """Show how managed docs differ from the standard's render (read-only).
+
+    Compares each fenced managed doc against what the current standard would
+    render from `.kickstart/scaffold.json`. Exit codes: 0 = in sync, 1 = drift
+    or structural findings, 2 = usage error (no repo or no plannable manifest).
+    """
+    try:
+        report = inspect_docs(path)
+    except DocsPlanTargetError as error:
+        print(f"[red]{escape(str(error))}[/]")
+        raise typer.Exit(code=2) from error
+
+    if json_output:
+        # Machine-readable output must bypass rich: console printing wraps
+        # long lines and interprets bracketed path segments as markup, both
+        # of which corrupt the JSON.
+        typer.echo(report.to_json(), nl=False)
+    else:
+        print(f"[bold]Docs plan for {escape(str(report.root))}[/]")
+        for entry in report.entries:
+            if entry.ok:
+                suffix = f" (profile: {escape(entry.profile)})" if entry.profile else ""
+                print(f"  [green]{entry.status}[/]  {escape(entry.target)}{suffix}")
+            else:
+                print(f"  [red]{entry.status}[/]  {escape(entry.target)} ({escape(entry.detail)})")
+                if entry.diff:
+                    typer.echo(entry.diff, nl=False)
+
+    raise typer.Exit(code=0 if report.in_sync else 1)
 
 
 @app.command()

--- a/src/generator/adoption.py
+++ b/src/generator/adoption.py
@@ -13,7 +13,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from src.utils.errors import KickstartError
+from src.generator.scaffold_contract import load_parsed_manifest
+from src.utils.errors import KickstartError, ManifestShapeError
 
 
 class AdoptionTargetError(KickstartError):
@@ -82,12 +83,9 @@ class AdoptionReport:
 def _manifest_issue(manifest_file: Path) -> str:
     """Validate that an existing scaffold manifest is parseable and shaped."""
     try:
-        manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        return f"unreadable manifest: {error}"
-
-    if not isinstance(manifest, dict):
-        return "manifest is not a JSON object"
+        manifest = load_parsed_manifest(manifest_file)
+    except ManifestShapeError as error:
+        return str(error)
 
     missing_keys = [key for key in ("schema_version", "project", "lifecycle") if key not in manifest]
     if missing_keys:

--- a/src/generator/docs_plan.py
+++ b/src/generator/docs_plan.py
@@ -1,0 +1,202 @@
+"""Read-only docs drift plan: re-render managed docs and compare.
+
+Scope wall (documented in ``docs/contracts/plan-drift-scope.md``): this module
+covers exactly the registry-rendered markdown projections inside their
+ownership fences. Broader envelope drift — Makefile targets, CI workflows,
+artifact files — belongs to the schema-4.0 drift check; inserting fences into
+pre-fence repos belongs to the adopt write path. Nothing here mutates the
+repository.
+
+Statuses per managed artifact:
+
+- ``in-sync``: the fenced region matches a candidate render byte-for-byte.
+- ``would-create``: the managed file is missing.
+- ``content-drift``: the fenced region differs (a unified diff is attached).
+- ``unfenced``: the file exists with no fence — a pre-fence scaffold or
+  hand-written file; reported as a structural fact, content never compared.
+- ``malformed-markers``: fail-closed marker parsing rejected the file.
+- ``unreadable``: the file could not be read as UTF-8 text.
+- ``presence-only``: the architecture README, whose content needs
+  generation-time inputs (title, directory list) a schema-3.0 manifest never
+  recorded; only its existence is checked.
+
+A worker-kind manifest cannot say which language generated it (the schema-3.0
+expressiveness gap), so worker repos are compared against both the TypeScript
+worker docs profile and the default profile and match either.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from src.generator.adoption import MANIFEST_PATH
+from src.generator.markers import find_fenced_region
+from src.generator.projections import (
+    PROFILE_DEFAULT,
+    PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER,
+    DocsProjection,
+    ProjectionProfile,
+    scaffold_docs_projections,
+)
+from src.generator.scaffold_contract import ScaffoldContract
+from src.utils.errors import KickstartError, ManifestShapeError, MarkerError
+
+ARCHITECTURE_README = "docs/architecture/README.md"
+
+
+class DocsPlanTargetError(KickstartError):
+    """Raised when the target repo or its manifest cannot be planned against."""
+
+
+@dataclass(frozen=True)
+class DocsPlanEntry:
+    """Plan result for one managed docs artifact."""
+
+    artifact_id: str
+    target: str
+    status: str
+    detail: str = ""
+    diff: str = ""
+    profile: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.status in ("in-sync", "presence-only")
+
+
+@dataclass(frozen=True)
+class DocsPlanReport:
+    """Result of a read-only docs plan."""
+
+    root: Path
+    entries: tuple[DocsPlanEntry, ...]
+
+    @property
+    def in_sync(self) -> bool:
+        return all(entry.ok for entry in self.entries)
+
+    def to_json(self) -> str:
+        """Machine-readable report for agents and CI."""
+        payload = {
+            "root": str(self.root),
+            "in_sync": self.in_sync,
+            "entries": [
+                {
+                    "artifact": entry.artifact_id,
+                    "target": entry.target,
+                    "status": entry.status,
+                    "detail": entry.detail,
+                    "diff": entry.diff,
+                    "profile": entry.profile,
+                }
+                for entry in self.entries
+            ],
+        }
+        return json.dumps(payload, indent=2) + "\n"
+
+
+def inspect_docs(root: Path) -> DocsPlanReport:
+    """Plan the managed docs of an existing repository, read-only."""
+    if not root.is_dir():
+        raise DocsPlanTargetError(f"plan target '{root}' is not an existing directory")
+    resolved = root.resolve()
+
+    contract = _contract_from_repo(resolved)
+    profiles = _candidate_profiles(contract)
+    candidates = {profile: scaffold_docs_projections(contract, profile) for profile in profiles}
+
+    entries = [
+        _plan_entry(resolved, index, profiles, candidates)
+        for index in range(len(candidates[profiles[0]]))
+    ]
+    entries.append(_architecture_entry(resolved))
+    return DocsPlanReport(root=resolved, entries=tuple(entries))
+
+
+def _contract_from_repo(resolved: Path) -> ScaffoldContract:
+    manifest_file = resolved / MANIFEST_PATH
+    try:
+        parsed = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise DocsPlanTargetError(
+            f"no readable scaffold manifest at {MANIFEST_PATH}: {error}"
+        ) from error
+    except json.JSONDecodeError as error:
+        raise DocsPlanTargetError(f"scaffold manifest is not valid JSON: {error}") from error
+    if not isinstance(parsed, dict):
+        raise DocsPlanTargetError("scaffold manifest is not a JSON object")
+    try:
+        return ScaffoldContract.from_manifest(parsed)
+    except ManifestShapeError as error:
+        raise DocsPlanTargetError(f"scaffold manifest cannot be planned against: {error}") from error
+
+
+def _candidate_profiles(contract: ScaffoldContract) -> tuple[ProjectionProfile, ...]:
+    # Schema 3.0 never recorded worker language, so a worker manifest is
+    # ambiguous between the TS worker docs profile and the default docs a
+    # Rust worker gets; accept a byte-exact match against either.
+    if contract.project_kind == "worker":
+        return (PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER, PROFILE_DEFAULT)
+    return (PROFILE_DEFAULT,)
+
+
+def _plan_entry(
+    resolved: Path,
+    index: int,
+    profiles: tuple[ProjectionProfile, ...],
+    candidates: dict[ProjectionProfile, tuple[DocsProjection, ...]],
+) -> DocsPlanEntry:
+    projection = candidates[profiles[0]][index]
+    path = resolved / projection.target
+    if not path.is_file():
+        return DocsPlanEntry(projection.id, projection.target, "would-create", detail="managed file missing")
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        return DocsPlanEntry(projection.id, projection.target, "unreadable", detail=str(error))
+
+    try:
+        region = find_fenced_region(text, projection.id)
+    except MarkerError as error:
+        return DocsPlanEntry(projection.id, projection.target, "malformed-markers", detail=str(error))
+    if region is None:
+        return DocsPlanEntry(
+            projection.id,
+            projection.target,
+            "unfenced",
+            detail="no ownership fence (pre-fence scaffold or hand-written file); content not compared",
+        )
+
+    for profile in profiles:
+        if region.inner == candidates[profile][index].body:
+            return DocsPlanEntry(projection.id, projection.target, "in-sync", profile=profile)
+
+    expected = projection.body
+    diff = "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            region.inner.splitlines(keepends=True),
+            fromfile=f"expected/{projection.target}",
+            tofile=f"actual/{projection.target}",
+        )
+    )
+    detail = "owned region differs from the current standard's render"
+    if len(profiles) > 1:
+        detail += " (no candidate docs profile matched)"
+    return DocsPlanEntry(projection.id, projection.target, "content-drift", detail=detail, diff=diff)
+
+
+def _architecture_entry(resolved: Path) -> DocsPlanEntry:
+    detail = (
+        "content needs generation-time inputs (title, directory list) a schema-3.0 "
+        "manifest does not record; presence checked only"
+    )
+    if (resolved / ARCHITECTURE_README).is_file():
+        return DocsPlanEntry("architecture-readme", ARCHITECTURE_README, "presence-only", detail=detail)
+    return DocsPlanEntry(
+        "architecture-readme", ARCHITECTURE_README, "would-create", detail="managed file missing"
+    )

--- a/src/generator/docs_plan.py
+++ b/src/generator/docs_plan.py
@@ -11,7 +11,8 @@ Statuses per managed artifact:
 
 - ``in-sync``: the fenced region matches a candidate render byte-for-byte.
 - ``would-create``: the managed file is missing.
-- ``content-drift``: the fenced region differs (a unified diff is attached).
+- ``content-drift``: the fenced region differs (a unified diff against the
+  closest candidate render is attached).
 - ``unfenced``: the file exists with no fence — a pre-fence scaffold or
   hand-written file; reported as a structural fact, content never compared.
 - ``malformed-markers``: fail-closed marker parsing rejected the file.
@@ -31,20 +32,33 @@ import difflib
 import json
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from src.generator.adoption import MANIFEST_PATH
 from src.generator.markers import find_fenced_region
 from src.generator.projections import (
+    ARCHITECTURE_README_ID,
+    ARCHITECTURE_README_TARGET,
     PROFILE_DEFAULT,
     PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER,
     DocsProjection,
     ProjectionProfile,
     scaffold_docs_projections,
 )
-from src.generator.scaffold_contract import ScaffoldContract
+from src.generator.scaffold_contract import ScaffoldContract, load_parsed_manifest
 from src.utils.errors import KickstartError, ManifestShapeError, MarkerError
 
-ARCHITECTURE_README = "docs/architecture/README.md"
+PlanStatus = Literal[
+    "in-sync",
+    "presence-only",
+    "would-create",
+    "content-drift",
+    "unfenced",
+    "malformed-markers",
+    "unreadable",
+]
+
+_MISSING_DETAIL = "managed file missing"
 
 
 class DocsPlanTargetError(KickstartError):
@@ -57,7 +71,7 @@ class DocsPlanEntry:
 
     artifact_id: str
     target: str
-    status: str
+    status: PlanStatus
     detail: str = ""
     diff: str = ""
     profile: str = ""
@@ -106,32 +120,22 @@ def inspect_docs(root: Path) -> DocsPlanReport:
 
     contract = _contract_from_repo(resolved)
     profiles = _candidate_profiles(contract)
-    candidates = {profile: scaffold_docs_projections(contract, profile) for profile in profiles}
+    renders = tuple(scaffold_docs_projections(contract, profile) for profile in profiles)
 
     entries = [
-        _plan_entry(resolved, index, profiles, candidates)
-        for index in range(len(candidates[profiles[0]]))
+        _plan_entry(resolved, profiles, variants)
+        for variants in zip(*renders, strict=True)
     ]
     entries.append(_architecture_entry(resolved))
     return DocsPlanReport(root=resolved, entries=tuple(entries))
 
 
 def _contract_from_repo(resolved: Path) -> ScaffoldContract:
-    manifest_file = resolved / MANIFEST_PATH
     try:
-        parsed = json.loads(manifest_file.read_text(encoding="utf-8"))
-    except OSError as error:
-        raise DocsPlanTargetError(
-            f"no readable scaffold manifest at {MANIFEST_PATH}: {error}"
-        ) from error
-    except json.JSONDecodeError as error:
-        raise DocsPlanTargetError(f"scaffold manifest is not valid JSON: {error}") from error
-    if not isinstance(parsed, dict):
-        raise DocsPlanTargetError("scaffold manifest is not a JSON object")
-    try:
+        parsed = load_parsed_manifest(resolved / MANIFEST_PATH)
         return ScaffoldContract.from_manifest(parsed)
     except ManifestShapeError as error:
-        raise DocsPlanTargetError(f"scaffold manifest cannot be planned against: {error}") from error
+        raise DocsPlanTargetError(f"cannot plan against {MANIFEST_PATH}: {error}") from error
 
 
 def _candidate_profiles(contract: ScaffoldContract) -> tuple[ProjectionProfile, ...]:
@@ -145,14 +149,13 @@ def _candidate_profiles(contract: ScaffoldContract) -> tuple[ProjectionProfile, 
 
 def _plan_entry(
     resolved: Path,
-    index: int,
     profiles: tuple[ProjectionProfile, ...],
-    candidates: dict[ProjectionProfile, tuple[DocsProjection, ...]],
+    variants: tuple[DocsProjection, ...],
 ) -> DocsPlanEntry:
-    projection = candidates[profiles[0]][index]
+    projection = variants[0]
     path = resolved / projection.target
     if not path.is_file():
-        return DocsPlanEntry(projection.id, projection.target, "would-create", detail="managed file missing")
+        return DocsPlanEntry(projection.id, projection.target, "would-create", detail=_MISSING_DETAIL)
 
     try:
         text = path.read_text(encoding="utf-8")
@@ -171,32 +174,45 @@ def _plan_entry(
             detail="no ownership fence (pre-fence scaffold or hand-written file); content not compared",
         )
 
-    for profile in profiles:
-        if region.inner == candidates[profile][index].body:
+    for profile, variant in zip(profiles, variants, strict=True):
+        if region.inner == variant.body:
             return DocsPlanEntry(projection.id, projection.target, "in-sync", profile=profile)
 
-    expected = projection.body
-    diff = "".join(
-        difflib.unified_diff(
-            expected.splitlines(keepends=True),
-            region.inner.splitlines(keepends=True),
-            fromfile=f"expected/{projection.target}",
-            tofile=f"actual/{projection.target}",
-        )
-    )
+    # Diff against the closest candidate so the report shows the real drift
+    # instead of a wholesale replacement against an arbitrary profile.
+    candidate_diffs = [
+        (_unified_diff(variant.body, region.inner, projection.target), profile)
+        for profile, variant in zip(profiles, variants, strict=True)
+    ]
+    diff, profile = min(candidate_diffs, key=lambda pair: len(pair[0]))
     detail = "owned region differs from the current standard's render"
     if len(profiles) > 1:
-        detail += " (no candidate docs profile matched)"
+        detail += f" (closest candidate profile: {profile})"
     return DocsPlanEntry(projection.id, projection.target, "content-drift", detail=detail, diff=diff)
 
 
-def _architecture_entry(resolved: Path) -> DocsPlanEntry:
-    detail = (
-        "content needs generation-time inputs (title, directory list) a schema-3.0 "
-        "manifest does not record; presence checked only"
+def _unified_diff(expected: str, actual: str, target: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            expected.splitlines(keepends=True),
+            actual.splitlines(keepends=True),
+            fromfile=f"expected/{target}",
+            tofile=f"actual/{target}",
+        )
     )
-    if (resolved / ARCHITECTURE_README).is_file():
-        return DocsPlanEntry("architecture-readme", ARCHITECTURE_README, "presence-only", detail=detail)
+
+
+def _architecture_entry(resolved: Path) -> DocsPlanEntry:
+    if (resolved / ARCHITECTURE_README_TARGET).is_file():
+        return DocsPlanEntry(
+            ARCHITECTURE_README_ID,
+            ARCHITECTURE_README_TARGET,
+            "presence-only",
+            detail=(
+                "content needs generation-time inputs (title, directory list) a schema-3.0 "
+                "manifest does not record; presence checked only"
+            ),
+        )
     return DocsPlanEntry(
-        "architecture-readme", ARCHITECTURE_README, "would-create", detail="managed file missing"
+        ARCHITECTURE_README_ID, ARCHITECTURE_README_TARGET, "would-create", detail=_MISSING_DETAIL
     )

--- a/src/generator/docs_plan.py
+++ b/src/generator/docs_plan.py
@@ -19,7 +19,8 @@ Statuses per managed artifact:
 - ``unreadable``: the file could not be read as UTF-8 text.
 - ``presence-only``: the architecture README, whose content needs
   generation-time inputs (title, directory list) a schema-3.0 manifest never
-  recorded; only its existence is checked.
+  recorded; its ownership fence is still parsed and verified, only the byte
+  comparison is skipped.
 
 A worker-kind manifest cannot say which language generated it (the schema-3.0
 expressiveness gap), so worker repos are compared against both the TypeScript
@@ -35,7 +36,7 @@ from pathlib import Path
 from typing import Literal
 
 from src.generator.adoption import MANIFEST_PATH
-from src.generator.markers import find_fenced_region
+from src.generator.markers import FencedRegion, find_fenced_region
 from src.generator.projections import (
     ARCHITECTURE_README_ID,
     ARCHITECTURE_README_TARGET,
@@ -147,32 +148,41 @@ def _candidate_profiles(contract: ScaffoldContract) -> tuple[ProjectionProfile, 
     return (PROFILE_DEFAULT,)
 
 
+def _owned_region_or_entry(resolved: Path, artifact_id: str, target: str) -> FencedRegion | DocsPlanEntry:
+    """Resolve a managed file to its owned region, or the entry explaining why not."""
+    path = resolved / target
+    if not path.is_file():
+        return DocsPlanEntry(artifact_id, target, "would-create", detail=_MISSING_DETAIL)
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        return DocsPlanEntry(artifact_id, target, "unreadable", detail=str(error))
+
+    try:
+        region = find_fenced_region(text, artifact_id)
+    except MarkerError as error:
+        return DocsPlanEntry(artifact_id, target, "malformed-markers", detail=str(error))
+    if region is None:
+        return DocsPlanEntry(
+            artifact_id,
+            target,
+            "unfenced",
+            detail="no ownership fence (pre-fence scaffold or hand-written file); content not compared",
+        )
+    return region
+
+
 def _plan_entry(
     resolved: Path,
     profiles: tuple[ProjectionProfile, ...],
     variants: tuple[DocsProjection, ...],
 ) -> DocsPlanEntry:
     projection = variants[0]
-    path = resolved / projection.target
-    if not path.is_file():
-        return DocsPlanEntry(projection.id, projection.target, "would-create", detail=_MISSING_DETAIL)
-
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError) as error:
-        return DocsPlanEntry(projection.id, projection.target, "unreadable", detail=str(error))
-
-    try:
-        region = find_fenced_region(text, projection.id)
-    except MarkerError as error:
-        return DocsPlanEntry(projection.id, projection.target, "malformed-markers", detail=str(error))
-    if region is None:
-        return DocsPlanEntry(
-            projection.id,
-            projection.target,
-            "unfenced",
-            detail="no ownership fence (pre-fence scaffold or hand-written file); content not compared",
-        )
+    resolution = _owned_region_or_entry(resolved, projection.id, projection.target)
+    if isinstance(resolution, DocsPlanEntry):
+        return resolution
+    region = resolution
 
     for profile, variant in zip(profiles, variants, strict=True):
         if region.inner == variant.body:
@@ -203,16 +213,17 @@ def _unified_diff(expected: str, actual: str, target: str) -> str:
 
 
 def _architecture_entry(resolved: Path) -> DocsPlanEntry:
-    if (resolved / ARCHITECTURE_README_TARGET).is_file():
-        return DocsPlanEntry(
-            ARCHITECTURE_README_ID,
-            ARCHITECTURE_README_TARGET,
-            "presence-only",
-            detail=(
-                "content needs generation-time inputs (title, directory list) a schema-3.0 "
-                "manifest does not record; presence checked only"
-            ),
-        )
+    # presence-only skips the byte comparison, never the ownership parsing:
+    # an unfenced or malformed architecture README must not read as managed.
+    resolution = _owned_region_or_entry(resolved, ARCHITECTURE_README_ID, ARCHITECTURE_README_TARGET)
+    if isinstance(resolution, DocsPlanEntry):
+        return resolution
     return DocsPlanEntry(
-        ARCHITECTURE_README_ID, ARCHITECTURE_README_TARGET, "would-create", detail=_MISSING_DETAIL
+        ARCHITECTURE_README_ID,
+        ARCHITECTURE_README_TARGET,
+        "presence-only",
+        detail=(
+            "fence verified; content needs generation-time inputs (title, directory list) "
+            "a schema-3.0 manifest does not record, so bytes are not compared"
+        ),
     )

--- a/src/generator/projections.py
+++ b/src/generator/projections.py
@@ -42,6 +42,11 @@ ProjectionProfile = Literal["default", "typescript-cloudflare-worker"]
 PROFILE_DEFAULT: ProjectionProfile = "default"
 PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER: ProjectionProfile = "typescript-cloudflare-worker"
 
+# Canonical identity of the architecture projection, shared with tooling that
+# must reference it without rendering it (its inputs are generation-time).
+ARCHITECTURE_README_ID = "architecture-readme"
+ARCHITECTURE_README_TARGET = "docs/architecture/README.md"
+
 
 @dataclass(frozen=True)
 class DocsProjection:
@@ -75,8 +80,8 @@ def architecture_readme_projection(
 ) -> DocsProjection:
     """Render the architecture README as a managed projection."""
     return _fenced_projection(
-        "architecture-readme",
-        "docs/architecture/README.md",
+        ARCHITECTURE_README_ID,
+        ARCHITECTURE_README_TARGET,
         render_architecture_readme(title, directories, contract),
     )
 

--- a/src/generator/scaffold_contract.py
+++ b/src/generator/scaffold_contract.py
@@ -2,9 +2,10 @@
 
 from dataclasses import dataclass, field
 import json
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict, cast
 
 from src import __version__
+from src.utils.errors import ManifestShapeError
 
 
 ProjectKind = Literal["service", "worker", "frontend", "library", "cli", "system"]
@@ -16,6 +17,43 @@ RepoLayout = Literal["single-project", "monorepo"]
 # generating version's tag so the referenced semantics cannot drift under a
 # manifest that has already been written.
 SEMANTICS_REFERENCE = f"https://github.com/woud420/kickstart/blob/v{__version__}/docs/scaffold-contract.md"
+
+_PROJECT_KINDS: frozenset[str] = frozenset({"service", "worker", "frontend", "library", "cli", "system"})
+_REPO_LAYOUTS: frozenset[str] = frozenset({"single-project", "monorepo"})
+
+# Parsed-JSON shape for on-disk manifests: precise about what json.loads can
+# actually produce, unlike a loose catch-all annotation.
+JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
+ParsedManifest = dict[str, JsonValue]
+
+
+def _require_mapping(value: "JsonValue | None", description: str) -> ParsedManifest:
+    """Return the value as a JSON object or fail with its manifest path."""
+    if not isinstance(value, dict):
+        raise ManifestShapeError(f"manifest {description} is not an object")
+    return value
+
+
+def _optional_string(mapping: ParsedManifest, key: str) -> str | None:
+    """Return a string field or None; a present non-string value is a shape error."""
+    value = mapping.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ManifestShapeError(f"manifest field '{key}' is not a string")
+    return value
+
+
+def _string_items(value: "JsonValue | None", description: str) -> tuple[str, ...]:
+    """Return a list-of-strings field as a tuple, failing on other shapes."""
+    if not isinstance(value, list):
+        raise ManifestShapeError(f"manifest {description} is not a list of strings")
+    items: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            raise ManifestShapeError(f"manifest {description} is not a list of strings")
+        items.append(item)
+    return tuple(items)
 
 
 class ScaffoldProjectManifest(TypedDict):
@@ -320,6 +358,83 @@ class ScaffoldContract:
             install="make install",
             test="make test",
             check="make check",
+        )
+
+    @classmethod
+    def from_manifest(cls, manifest: ParsedManifest) -> "ScaffoldContract":
+        """Rebuild the contract fields tooling consumes from a parsed manifest.
+
+        Inverse of ``manifest()`` for schema 3.x, written defensively because
+        the input is an on-disk file: required keys and shapes raise
+        ``ManifestShapeError`` instead of guessing. Generation-time inputs the
+        manifest never recorded (docs projection profile, architecture title
+        and directories) cannot be recovered here; consumers own that gap.
+        """
+        project = _require_mapping(manifest.get("project"), "project")
+        execution = _require_mapping(manifest.get("execution"), "execution")
+        kind = project.get("kind")
+        if not isinstance(kind, str) or kind not in _PROJECT_KINDS:
+            raise ManifestShapeError(f"unsupported project.kind: {kind!r}")
+        repo_layout = project.get("repo_layout", "single-project")
+        if not isinstance(repo_layout, str) or repo_layout not in _REPO_LAYOUTS:
+            raise ManifestShapeError(f"unsupported project.repo_layout: {repo_layout!r}")
+
+        artifacts = _require_mapping(manifest.get("artifacts", {}), "artifacts")
+        lifecycle = _require_mapping(manifest.get("lifecycle", {}), "lifecycle")
+        capabilities = _require_mapping(manifest.get("capabilities", {}), "capabilities")
+        extensions = _require_mapping(
+            capabilities.get("service_extensions", {}), "capabilities.service_extensions"
+        )
+        provider = _require_mapping(manifest.get("provider", {}), "provider")
+
+        workspace_tooling = "none"
+        composition = manifest.get("composition")
+        if isinstance(composition, dict):
+            tooling = composition.get("workspace_tooling")
+            if isinstance(tooling, str):
+                workspace_tooling = tooling
+
+        knowledge_adapter = manifest.get("knowledge_adapter", "none")
+        schema_version = manifest.get("schema_version", "3.0")
+
+        return cls(
+            project_kind=cast(ProjectKind, kind),
+            execution_models=_string_items(execution.get("models", []), "execution.models"),
+            runtime_platforms=_string_items(execution.get("platforms", []), "execution.platforms"),
+            artifacts=ScaffoldArtifacts(
+                image=_optional_string(artifacts, "image"),
+                kubernetes=_optional_string(artifacts, "kubernetes"),
+                local=_optional_string(artifacts, "local"),
+                package=_optional_string(artifacts, "package"),
+                static_site=_optional_string(artifacts, "static_site"),
+                worker=_optional_string(artifacts, "worker"),
+                iac=_optional_string(artifacts, "iac"),
+                ci=_optional_string(artifacts, "ci"),
+            ),
+            lifecycle=ScaffoldLifecycle(
+                install=_optional_string(lifecycle, "install"),
+                test=_optional_string(lifecycle, "test"),
+                check=_optional_string(lifecycle, "check"),
+                build=_optional_string(lifecycle, "build"),
+                dev=_optional_string(lifecycle, "dev"),
+                deploy=_optional_string(lifecycle, "deploy"),
+            ),
+            service_extensions=ScaffoldServiceExtensions(
+                database=_optional_string(extensions, "database"),
+                cache=_optional_string(extensions, "cache"),
+                auth=_optional_string(extensions, "auth"),
+            ),
+            provider_targets=_string_items(provider.get("targets", []), "provider.targets"),
+            knowledge_adapter=knowledge_adapter if isinstance(knowledge_adapter, str) else "none",
+            repo_layout=cast(RepoLayout, repo_layout),
+            workspace_tooling=workspace_tooling,
+            architecture=_optional_string(project, "architecture"),
+            cli_framework=_optional_string(project, "cli_framework"),
+            command_root=_optional_string(project, "command_root"),
+            entrypoint=_optional_string(project, "entrypoint"),
+            operation_root=_optional_string(project, "operation_root"),
+            src_root_files=_string_items(project.get("src_root_files", []), "project.src_root_files"),
+            schema_version=schema_version if isinstance(schema_version, str) else "3.0",
         )
 
     @property

--- a/src/generator/scaffold_contract.py
+++ b/src/generator/scaffold_contract.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 import json
+from pathlib import Path
 from typing import Literal, NotRequired, TypedDict, cast
 
 from src import __version__
@@ -25,6 +26,24 @@ _REPO_LAYOUTS: frozenset[str] = frozenset({"single-project", "monorepo"})
 # actually produce, unlike a loose catch-all annotation.
 JsonValue = str | int | float | bool | None | list["JsonValue"] | dict[str, "JsonValue"]
 ParsedManifest = dict[str, JsonValue]
+
+
+def load_parsed_manifest(manifest_file: "Path") -> ParsedManifest:
+    """Read and parse an on-disk scaffold manifest, fail-closed.
+
+    The single loader both `adopt --check` and `plan` sit on, so the two
+    commands can never disagree about what counts as a readable manifest.
+    Raises ``ManifestShapeError`` with a human-readable reason.
+    """
+    try:
+        parsed = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError) as error:
+        raise ManifestShapeError(f"unreadable manifest: {error}") from error
+    except json.JSONDecodeError as error:
+        raise ManifestShapeError(f"manifest is not valid JSON: {error}") from error
+    if not isinstance(parsed, dict):
+        raise ManifestShapeError("manifest is not a JSON object")
+    return parsed
 
 
 def _require_mapping(value: "JsonValue | None", description: str) -> ParsedManifest:
@@ -395,7 +414,11 @@ class ScaffoldContract:
                 workspace_tooling = tooling
 
         knowledge_adapter = manifest.get("knowledge_adapter", "none")
+        if not isinstance(knowledge_adapter, str):
+            raise ManifestShapeError("manifest field 'knowledge_adapter' is not a string")
         schema_version = manifest.get("schema_version", "3.0")
+        if not isinstance(schema_version, str):
+            raise ManifestShapeError("manifest field 'schema_version' is not a string")
 
         return cls(
             project_kind=cast(ProjectKind, kind),
@@ -425,7 +448,7 @@ class ScaffoldContract:
                 auth=_optional_string(extensions, "auth"),
             ),
             provider_targets=_string_items(provider.get("targets", []), "provider.targets"),
-            knowledge_adapter=knowledge_adapter if isinstance(knowledge_adapter, str) else "none",
+            knowledge_adapter=knowledge_adapter,
             repo_layout=cast(RepoLayout, repo_layout),
             workspace_tooling=workspace_tooling,
             architecture=_optional_string(project, "architecture"),
@@ -434,7 +457,7 @@ class ScaffoldContract:
             entrypoint=_optional_string(project, "entrypoint"),
             operation_root=_optional_string(project, "operation_root"),
             src_root_files=_string_items(project.get("src_root_files", []), "project.src_root_files"),
-            schema_version=schema_version if isinstance(schema_version, str) else "3.0",
+            schema_version=schema_version,
         )
 
     @property

--- a/src/generator/scaffold_contract.py
+++ b/src/generator/scaffold_contract.py
@@ -416,9 +416,13 @@ class ScaffoldContract:
         knowledge_adapter = manifest.get("knowledge_adapter", "none")
         if not isinstance(knowledge_adapter, str):
             raise ManifestShapeError("manifest field 'knowledge_adapter' is not a string")
-        schema_version = manifest.get("schema_version", "3.0")
+        schema_version = manifest.get("schema_version")
         if not isinstance(schema_version, str):
-            raise ManifestShapeError("manifest field 'schema_version' is not a string")
+            raise ManifestShapeError("manifest schema_version is missing or not a string")
+        if schema_version.split(".", 1)[0] != "3":
+            raise ManifestShapeError(
+                f"unsupported manifest schema_version '{schema_version}': this inverse understands 3.x only"
+            )
 
         return cls(
             project_kind=cast(ProjectKind, kind),

--- a/src/utils/errors.py
+++ b/src/utils/errors.py
@@ -64,6 +64,11 @@ class MarkerError(KickstartError):
     pass
 
 
+class ManifestShapeError(KickstartError):
+    """Raised when a scaffold manifest cannot be interpreted as a contract."""
+    pass
+
+
 class UnsupportedOptionError(KickstartError):
     """Raised when an option does not apply to the selected project type."""
     pass

--- a/tests/integration/test_plan_command.py
+++ b/tests/integration/test_plan_command.py
@@ -1,0 +1,71 @@
+"""kickstart plan end-to-end: generate a scaffold, drift it, read the report."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.integration.conftest import KickstartRunner
+
+
+def _create_service(kickstart_run: KickstartRunner, repo_root: Path, root: Path) -> Path:
+    completed = kickstart_run(
+        "create",
+        "service",
+        "planned-api",
+        "--lang",
+        "python",
+        "--root",
+        str(root),
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, f"generation failed:\n{completed.stdout}\n{completed.stderr}"
+    return root / "planned-api"
+
+
+def test_plan_is_green_on_a_fresh_scaffold(
+    kickstart_run: KickstartRunner, repo_root: Path, tmp_path: Path
+) -> None:
+    project = _create_service(kickstart_run, repo_root, tmp_path)
+
+    completed = kickstart_run(
+        "plan", str(project), "--json", cwd=repo_root, capture_output=True, text=True
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload["in_sync"] is True
+
+
+def test_plan_reports_fence_edits_but_tolerates_user_content(
+    kickstart_run: KickstartRunner, repo_root: Path, tmp_path: Path
+) -> None:
+    project = _create_service(kickstart_run, repo_root, tmp_path)
+    agents = project / "AGENTS.md"
+
+    agents.write_text(
+        agents.read_text(encoding="utf-8") + "\n## Team conventions\n\nUser-owned notes.\n",
+        encoding="utf-8",
+    )
+    outside_only = kickstart_run("plan", str(project), cwd=repo_root, capture_output=True, text=True)
+
+    agents.write_text(
+        agents.read_text(encoding="utf-8").replace("orientation surface", "renamed surface"),
+        encoding="utf-8",
+    )
+    drifted = kickstart_run("plan", str(project), cwd=repo_root, capture_output=True, text=True)
+
+    assert outside_only.returncode == 0, outside_only.stdout + outside_only.stderr
+    assert drifted.returncode == 1
+    assert "content-drift" in drifted.stdout
+    assert "renamed surface" in drifted.stdout
+
+
+def test_plan_without_a_manifest_is_a_usage_error(
+    kickstart_run: KickstartRunner, repo_root: Path, tmp_path: Path
+) -> None:
+    completed = kickstart_run("plan", str(tmp_path), cwd=repo_root, capture_output=True, text=True)
+
+    assert completed.returncode == 2

--- a/tests/unit/generator/test_adoption.py
+++ b/tests/unit/generator/test_adoption.py
@@ -56,7 +56,7 @@ def test_inspect_repo_flags_malformed_manifest(tmp_path: Path) -> None:
 
     manifest_status = next(status for status in report.artifacts if status.path == MANIFEST_PATH)
     assert manifest_status.present
-    assert "unreadable manifest" in manifest_status.issue
+    assert "not valid JSON" in manifest_status.issue
     assert not report.complete
 
 

--- a/tests/unit/generator/test_docs_plan.py
+++ b/tests/unit/generator/test_docs_plan.py
@@ -1,0 +1,228 @@
+"""Read-only docs plan: per-scenario statuses and manifest round-trips."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.generator.docs_plan import DocsPlanTargetError, inspect_docs
+from src.generator.markers import begin_marker
+from src.generator.projections import (
+    PROFILE_DEFAULT,
+    PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER,
+    ProjectionProfile,
+    scaffold_docs_projections,
+)
+from src.generator.scaffold_contract import ScaffoldArtifacts, ScaffoldContract
+from src.utils.errors import ManifestShapeError
+
+
+def _service_contract() -> ScaffoldContract:
+    return ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+        artifacts=ScaffoldArtifacts(image="dockerfile"),
+    )
+
+
+def _cli_contract() -> ScaffoldContract:
+    return ScaffoldContract(
+        project_kind="cli",
+        execution_models=("cli",),
+        runtime_platforms=("local",),
+        architecture="modular-cli",
+        cli_framework="typer",
+        command_root="src/cli/commands",
+        entrypoint="src/main.py",
+        operation_root="src/operations",
+        src_root_files=("main.py",),
+    )
+
+
+def _worker_contract() -> ScaffoldContract:
+    return ScaffoldContract(
+        project_kind="worker",
+        execution_models=("cloudflare-worker",),
+        runtime_platforms=("cloudflare-workers",),
+        artifacts=ScaffoldArtifacts(worker="wrangler"),
+        provider_targets=("cloudflare",),
+    )
+
+
+def _system_contract() -> ScaffoldContract:
+    return ScaffoldContract(
+        project_kind="system",
+        execution_models=("container",),
+        runtime_platforms=("kubernetes",),
+        artifacts=ScaffoldArtifacts(iac="terraform"),
+        repo_layout="monorepo",
+        workspace_tooling="bun-turbo",
+        knowledge_adapter="backstage",
+    )
+
+
+def _write_repo(root: Path, contract: ScaffoldContract, profile: ProjectionProfile = PROFILE_DEFAULT) -> None:
+    (root / ".kickstart").mkdir(parents=True, exist_ok=True)
+    (root / ".kickstart" / "scaffold.json").write_text(contract.manifest_json("planned"), encoding="utf-8")
+    for projection in scaffold_docs_projections(contract, profile):
+        path = root / projection.target
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(projection.content, encoding="utf-8")
+    architecture = root / "docs" / "architecture" / "README.md"
+    architecture.parent.mkdir(parents=True, exist_ok=True)
+    architecture.write_text("# planned Architecture\n", encoding="utf-8")
+
+
+def test_fresh_scaffold_is_in_sync(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+
+    report = inspect_docs(tmp_path)
+
+    assert report.in_sync
+    statuses = {entry.artifact_id: entry.status for entry in report.entries}
+    assert statuses["agent-map"] == "in-sync"
+    assert statuses["architecture-readme"] == "presence-only"
+
+
+def test_user_content_outside_fence_stays_in_sync(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text(agents.read_text(encoding="utf-8") + "\n## Team notes\n\nOurs.\n", encoding="utf-8")
+
+    report = inspect_docs(tmp_path)
+
+    assert report.in_sync
+
+
+def test_edit_inside_fence_is_content_drift_with_diff(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text(
+        agents.read_text(encoding="utf-8").replace("orientation surface", "renamed surface"),
+        encoding="utf-8",
+    )
+
+    report = inspect_docs(tmp_path)
+
+    entry = next(entry for entry in report.entries if entry.artifact_id == "agent-map")
+    assert not report.in_sync
+    assert entry.status == "content-drift"
+    assert "-" in entry.diff and "renamed surface" in entry.diff
+
+
+def test_unfenced_file_is_a_structural_fact(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+    (tmp_path / "AGENTS.md").write_text("# Agent Map\n\nhand-written\n", encoding="utf-8")
+
+    report = inspect_docs(tmp_path)
+
+    entry = next(entry for entry in report.entries if entry.artifact_id == "agent-map")
+    assert entry.status == "unfenced"
+    assert entry.diff == ""
+
+
+def test_missing_managed_file_is_would_create(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+    (tmp_path / "docs" / "contracts" / "README.md").unlink()
+
+    report = inspect_docs(tmp_path)
+
+    entry = next(entry for entry in report.entries if entry.artifact_id == "contracts-readme")
+    assert entry.status == "would-create"
+
+
+def test_malformed_markers_fail_closed(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text(agents.read_text(encoding="utf-8") + begin_marker("agent-map") + "\n", encoding="utf-8")
+
+    report = inspect_docs(tmp_path)
+
+    entry = next(entry for entry in report.entries if entry.artifact_id == "agent-map")
+    assert entry.status == "malformed-markers"
+
+
+def test_missing_architecture_readme_is_reported(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+    (tmp_path / "docs" / "architecture" / "README.md").unlink()
+
+    report = inspect_docs(tmp_path)
+
+    entry = next(entry for entry in report.entries if entry.artifact_id == "architecture-readme")
+    assert entry.status == "would-create"
+    assert not report.in_sync
+
+
+def test_worker_repo_matches_either_docs_profile(tmp_path: Path) -> None:
+    ts_root = tmp_path / "ts-worker"
+    rust_root = tmp_path / "rust-worker"
+    ts_root.mkdir()
+    rust_root.mkdir()
+    _write_repo(ts_root, _worker_contract(), PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER)
+    _write_repo(rust_root, _worker_contract(), PROFILE_DEFAULT)
+
+    ts_report = inspect_docs(ts_root)
+    rust_report = inspect_docs(rust_root)
+
+    assert ts_report.in_sync
+    assert rust_report.in_sync
+    ts_agent = next(entry for entry in ts_report.entries if entry.artifact_id == "agent-map")
+    rust_agent = next(entry for entry in rust_report.entries if entry.artifact_id == "agent-map")
+    assert ts_agent.profile == PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER
+    assert rust_agent.profile == PROFILE_DEFAULT
+
+
+def test_missing_manifest_is_a_target_error(tmp_path: Path) -> None:
+    with pytest.raises(DocsPlanTargetError):
+        inspect_docs(tmp_path)
+
+
+def test_invalid_manifest_json_is_a_target_error(tmp_path: Path) -> None:
+    (tmp_path / ".kickstart").mkdir(parents=True)
+    (tmp_path / ".kickstart" / "scaffold.json").write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(DocsPlanTargetError):
+        inspect_docs(tmp_path)
+
+
+def test_report_json_shape(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+
+    payload = json.loads(inspect_docs(tmp_path).to_json())
+
+    assert payload["in_sync"] is True
+    assert {entry["artifact"] for entry in payload["entries"]} == {
+        "agent-map",
+        "contracts-readme",
+        "operations-readme",
+        "decisions-readme",
+        "architecture-readme",
+    }
+
+
+def test_manifest_round_trip_reproduces_projections() -> None:
+    for contract in (_service_contract(), _cli_contract(), _worker_contract(), _system_contract()):
+        manifest = json.loads(contract.manifest_json("planned"))
+
+        rebuilt = ScaffoldContract.from_manifest(manifest)
+
+        assert scaffold_docs_projections(rebuilt) == scaffold_docs_projections(contract)
+        if contract.project_kind == "worker":
+            assert scaffold_docs_projections(
+                rebuilt, PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER
+            ) == scaffold_docs_projections(contract, PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER)
+
+
+def test_from_manifest_rejects_bad_shapes() -> None:
+    good = json.loads(_service_contract().manifest_json("planned"))
+
+    no_project = {key: value for key, value in good.items() if key != "project"}
+    bad_kind = json.loads(json.dumps(good))
+    bad_kind["project"]["kind"] = "spaceship"
+    bad_models = json.loads(json.dumps(good))
+    bad_models["execution"]["models"] = "container"
+
+    for manifest in (no_project, bad_kind, bad_models):
+        with pytest.raises(ManifestShapeError):
+            ScaffoldContract.from_manifest(manifest)

--- a/tests/unit/generator/test_docs_plan.py
+++ b/tests/unit/generator/test_docs_plan.py
@@ -222,7 +222,11 @@ def test_from_manifest_rejects_bad_shapes() -> None:
     bad_kind["project"]["kind"] = "spaceship"
     bad_models = json.loads(json.dumps(good))
     bad_models["execution"]["models"] = "container"
+    bad_schema = json.loads(json.dumps(good))
+    bad_schema["schema_version"] = 4
+    bad_knowledge = json.loads(json.dumps(good))
+    bad_knowledge["knowledge_adapter"] = {"kind": "backstage"}
 
-    for manifest in (no_project, bad_kind, bad_models):
+    for manifest in (no_project, bad_kind, bad_models, bad_schema, bad_knowledge):
         with pytest.raises(ManifestShapeError):
             ScaffoldContract.from_manifest(manifest)

--- a/tests/unit/generator/test_docs_plan.py
+++ b/tests/unit/generator/test_docs_plan.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from src.generator.docs_plan import DocsPlanTargetError, inspect_docs
-from src.generator.markers import begin_marker
+from src.generator.markers import begin_marker, fence
 from src.generator.projections import (
     PROFILE_DEFAULT,
     PROFILE_TYPESCRIPT_CLOUDFLARE_WORKER,
@@ -71,7 +71,7 @@ def _write_repo(root: Path, contract: ScaffoldContract, profile: ProjectionProfi
         path.write_text(projection.content, encoding="utf-8")
     architecture = root / "docs" / "architecture" / "README.md"
     architecture.parent.mkdir(parents=True, exist_ok=True)
-    architecture.write_text("# planned Architecture\n", encoding="utf-8")
+    architecture.write_text(fence("architecture-readme", "# planned Architecture\n"), encoding="utf-8")
 
 
 def test_fresh_scaffold_is_in_sync(tmp_path: Path) -> None:
@@ -152,6 +152,45 @@ def test_missing_architecture_readme_is_reported(tmp_path: Path) -> None:
     entry = next(entry for entry in report.entries if entry.artifact_id == "architecture-readme")
     assert entry.status == "would-create"
     assert not report.in_sync
+
+
+def test_unfenced_architecture_readme_is_not_presence_only(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+    (tmp_path / "docs" / "architecture" / "README.md").write_text("# hand-written map\n", encoding="utf-8")
+
+    report = inspect_docs(tmp_path)
+
+    entry = next(entry for entry in report.entries if entry.artifact_id == "architecture-readme")
+    assert entry.status == "unfenced"
+    assert not report.in_sync
+
+
+def test_malformed_architecture_fence_is_reported(tmp_path: Path) -> None:
+    _write_repo(tmp_path, _service_contract())
+    (tmp_path / "docs" / "architecture" / "README.md").write_text(
+        f"{begin_marker('architecture-readme')}\n# map without an end marker\n", encoding="utf-8"
+    )
+
+    report = inspect_docs(tmp_path)
+
+    entry = next(entry for entry in report.entries if entry.artifact_id == "architecture-readme")
+    assert entry.status == "malformed-markers"
+    assert not report.in_sync
+
+
+def test_from_manifest_rejects_unsupported_schema_versions(tmp_path: Path) -> None:
+    manifest = json.loads(_service_contract().manifest_json("planned"))
+
+    manifest["schema_version"] = "4.0"
+    with pytest.raises(ManifestShapeError):
+        ScaffoldContract.from_manifest(manifest)
+
+    del manifest["schema_version"]
+    with pytest.raises(ManifestShapeError):
+        ScaffoldContract.from_manifest(manifest)
+
+    manifest["schema_version"] = "3.1"
+    assert ScaffoldContract.from_manifest(manifest).schema_version == "3.1"
 
 
 def test_worker_repo_matches_either_docs_profile(tmp_path: Path) -> None:


### PR DESCRIPTION
## Primary changes

Stacked PR 3/6 (base: `docs-interface/02-ownership-fences`, PR #89). Adds the read-only docs-drift frontend: `kickstart plan REPO [--json]` re-renders the managed docs projections from `.kickstart/scaffold.json` and reports per-artifact status without mutating anything. This is the metadata review's §6 step-2 drift report scoped to the docs envelope, built as a library sibling of `adoption.py` per ENG-12's reuse notes — not a fork of the broader drift model.

Statuses: `in-sync` / `presence-only` (clean); `would-create`, `content-drift` (unified diff attached), `unfenced` (pre-fence scaffold — structural fact, content never compared), `malformed-markers`, `unreadable` (findings). Exit codes mirror `adopt --check`: 0 in sync / 1 findings / 2 usage error.

## Reviewer walkthrough

1. `src/generator/scaffold_contract.py` — `ScaffoldContract.from_manifest`: fail-closed inverse of `manifest()` for schema 3.x (new `ManifestShapeError`), with a precise recursive `JsonValue` type for parsed JSON instead of a loose catch-all (the type-hygiene audit rejects those, correctly).
2. `src/generator/docs_plan.py` — `inspect_docs`: manifest → contract → candidate profiles → per-artifact comparison inside fences only. Worker manifests can't record language (the ENG-159 gap), so worker repos match either the TS worker profile or the default profile, and the report says which matched. The architecture README is presence-checked only — its render needs generation-time inputs the manifest never recorded.
3. `src/cli/main.py` — the `plan` command, mirroring `adopt`'s output/exit-code/JSON-bypass patterns.
4. `docs/contracts/plan-drift-scope.md` — the scope wall: what plan covers, what it defers (full-envelope drift → schema-4.0 drift check; fence insertion → adopt write path; render-inputs recovery → metadata-review roadmap), and the JSON shape.
5. Tests: `tests/unit/generator/test_docs_plan.py` (every status class, worker two-profile ambiguity, manifest→contract→projections round-trip per kind, shape rejection) and `tests/integration/test_plan_command.py` (fresh scaffold green; user content outside fence stays green while a fence edit exits 1 with the diff in output; missing manifest exits 2).

## Correctness and invariants

Plan never writes. Content is only compared inside a successfully parsed fence; unfenced and malformed files produce structural findings, never diffs of user content — the PR #80 review's rule. The round-trip test (`manifest_json` → `from_manifest` → identical projections for service/cli/worker/system) is the invariant that makes regenerate-and-compare sound. User prose outside fences never affects the verdict (pinned by unit and integration tests).

## Testing and QA

`make check` green (564 passed, 1 pre-existing skip; lint/mypy/type-hygiene/template-audit clean). PR-tier evals pass (bootstrap CI cases 47s, weight baselines green). No generated-output change: golden fixture untouched.

## Risk / Rollout

Low: a new read-only command plus an inverse constructor; no generator or template changes. Known degraded case is documented rather than hidden: worker docs fidelity waits on schema 4.0's `project.language`. Follow-ups on the roadmap consume this library (tiered adopt reports fence readiness; the future apply/repair is gated behind the metadata review's go/no-go).

Refs ENG-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DY47fSSZLXnZQCB8ceFkwN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DY47fSSZLXnZQCB8ceFkwN)_