### PR TITLE
Add deterministic `kickstart export backstage` with derived/declared/passthrough field classes

### DIFF
--- a/.agents/skills/backstage-catalog/SKILL.md
+++ b/.agents/skills/backstage-catalog/SKILL.md
@@ -1,54 +1,51 @@
 ---
 name: backstage-catalog
-description: Derive a Backstage catalog-info.yaml from a kickstart-generated repo's .kickstart/scaffold.json. Use when asked to register a scaffolded or adopted project in a Backstage software catalog.
+description: Register a kickstart-generated or adopted repo in a Backstage software catalog using the deterministic `kickstart export backstage` verb, then fill in the human judgment fields. Use when asked to add a scaffolded or adopted project to Backstage.
 ---
 
-# Backstage Catalog Mapping
+# Backstage Catalog Registration
 
 ## Use When
 
-Use this skill when asked to add a kickstart-generated (or adopted) repo to
-a Backstage catalog. The mapping is derived from `.kickstart/scaffold.json`,
-so the catalog entry stays consistent with the scaffold contract instead of
-being hand-written.
+Use this skill when asked to add a kickstart-generated (or adopted) repo to a
+Backstage catalog. The mechanical mapping is owned by the deterministic verb —
+never hand-derive it; this skill supplies the judgment the verb deliberately
+does not.
 
-Catalog metadata is opt-in: `system` scaffolds created with
-`--knowledge backstage` already emit `catalog-info.yaml` and
-`backstage_template.yaml` — check for them first and update rather than
-duplicate. All other project kinds get their entry from this mapping.
+## Procedure
 
-## Mapping
-
-Read `.kickstart/scaffold.json` and emit `catalog-info.yaml` at the repo
-root:
-
-| catalog-info field | source |
-| --- | --- |
-| `apiVersion` | `backstage.io/v1alpha1` |
-| `kind` | `Component` (`System` additionally for `project.kind: system`) |
-| `metadata.name` | `project.name` (already DNS-label safe) |
-| `metadata.description` | `kickstart-generated <project.kind>` unless the README gives a better one-liner |
-| `metadata.annotations` | `backstage.io/techdocs-ref: dir:.` when `docs/` exists |
-| `metadata.tags` | `capabilities.service_extensions` values (for example `postgres`, `redis`, `jwt`) plus `execution.models` entries |
-| `spec.type` | `service` → `service`, `frontend` → `website`, `lib` → `library`, `cli` → `tool`, `system` → `system` |
-| `spec.lifecycle` | `experimental` unless the user states otherwise |
-| `spec.owner` | ask the user; default `group:default/platform` (matches the system template) |
-
-For `system` repos, also emit one `Component` per contained project listed
-in the scaffold's composition metadata, each with `spec.system` set to the
-system's name.
+1. Run `kickstart export backstage <repo>`. It derives `catalog-info.yaml`
+   from `.kickstart/scaffold.json`: derived fields (apiVersion, kind,
+   metadata name/tags/techdocs annotation, and for systems the System entity
+   plus child Components) sit inside `# kickstart:begin/end` fences and
+   refresh on every run; `spec.type`, `spec.lifecycle: experimental`, and
+   `spec.owner: group:default/unknown` are emitted once as anonymous
+   defaults and then belong to the user.
+2. Review the diff. Never overwrite by hand what the verb owns (inside the
+   fences); never let the verb own what humans decide (outside them). An
+   existing hand-written `catalog-info.yaml` is refused by the verb —
+   migrate it by moving its human fields outside a fresh export's fences.
+3. Fill in the judgment fields outside the fences:
+   - `spec.owner`: ask the user; replace the `group:default/unknown`
+     sentinel with the real owning group.
+   - `spec.lifecycle`: keep `experimental` unless the user states otherwise.
+   - `metadata.description`: add a one-liner if the README gives a better
+     one than none.
+4. Validate: the file parses as YAML and every entity has `apiVersion`,
+   `kind`, `metadata.name`, `spec.type`, `spec.lifecycle`, `spec.owner`
+   (the verb warns on missing required lines — resolve warnings before
+   reporting done).
 
 ## Rules
 
-- Derive from `.kickstart/scaffold.json`; do not guess fields the scaffold
-  does not state — omit them or ask.
-- Never overwrite an existing `catalog-info.yaml` without showing the diff.
+- The verb is the source of truth for derived fields; do not guess fields
+  the scaffold does not state — omit them or ask.
 - Keep names DNS-label safe (lowercase alphanumerics and dashes).
-- Validate the result parses as YAML and has `apiVersion`, `kind`,
-  `metadata.name`, `spec.type`, `spec.lifecycle`, and `spec.owner` before
-  reporting done.
+- Re-running the export must be a no-op when nothing changed; if it is not,
+  something edited inside a fence — restore via re-export and move the edit
+  outside.
 
 ## Report Back
 
-Report the emitted file path, the kind/type/owner chosen, and any scaffold
-fields that had no catalog equivalent.
+Report the file path, created/updated/unchanged, the owner and lifecycle
+chosen, and any scaffold fields that had no catalog equivalent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Purpose: kickstart generates deterministic starter repos for humans and coding a
 - Managed docs projections: `src/generator/projections.py`
 - Ownership fences: `src/generator/markers.py`
 - Docs drift plan: `src/generator/docs_plan.py`
+- Backstage export: `src/generator/backstage_export.py`
 - Template plans: `src/generator/template_plans.py`
 - Language setup plans: `src/generator/language_setup.py`
 - Scaffold metadata: `src/generator/scaffold_contract.py`

--- a/README.md
+++ b/README.md
@@ -99,11 +99,24 @@ Add Bun + Turbo workspace tooling when you want a TypeScript workspace at the sy
 poetry run kickstart create system product-stack --workspace-tooling bun-turbo
 ```
 
-Check an existing repo against the scaffold standard (read-only; exit 0 = matches, 1 = gaps, 2 = usage error):
+Check an existing repo against the scaffold standard (read-only; exit 0 = claimed level satisfied, 1 = gaps, 2 = usage error). Repos without a manifest are judged at Level 1 (conformant, vendor-neutral); a manifest claims Level 2 (managed):
 
 ```bash
-poetry run kickstart adopt path/to/repo --check          # human report
+poetry run kickstart adopt path/to/repo --check          # human report with achieved/claimed level
 poetry run kickstart adopt path/to/repo --check --json   # machine-readable, for agents and CI
+```
+
+Show how a repo's managed docs differ from what the current standard would render (read-only; exit 0 = in sync, 1 = findings, 2 = usage error):
+
+```bash
+poetry run kickstart plan path/to/repo                   # human report with diffs inside owned fences
+poetry run kickstart plan path/to/repo --json            # machine-readable, for agents and CI
+```
+
+Derive a Backstage catalog entry from the scaffold manifest (derived fields fenced and refreshed on re-export; owner/lifecycle stay user-owned after the first emit):
+
+```bash
+poetry run kickstart export backstage path/to/repo
 ```
 
 ## What It Generates

--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -49,6 +49,10 @@ Level 2 managed adds a valid manifest driving fence-managed docs. Tiers
 contract: `docs/contracts/adoption-tiers.md`. Generated projects verify
 themselves with `make check`; the success output names it.
 
+Catalog export: `kickstart export backstage REPO` derives catalog-info.yaml
+from the manifest (derived fields fenced and refreshed; owner/lifecycle/type
+user-owned after first emit). Contract: `docs/contracts/backstage-export.md`.
+
 Docs drift: `kickstart plan REPO --json` re-renders the managed docs
 projections from `.kickstart/scaffold.json` and reports per-artifact status
 (read-only; exit 0 in sync / 1 findings / 2 usage error). Scope contract:
@@ -61,6 +65,7 @@ projections from `.kickstart/scaffold.json` and reports per-artifact status
 - Generator specs: `src/generator/specs.py`
 - Directory plans: `src/generator/layouts.py`
 - Managed docs projections: `src/generator/projections.py`
+- Backstage export: `src/generator/backstage_export.py`
 - Scaffold contract: `src/generator/scaffold_contract.py`
 - Template plans: `src/generator/template_plans.py`
 - Language setup plans: `src/generator/language_setup.py`

--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -7,6 +7,7 @@ Current contract references:
 - [Scaffold Contract](../scaffold-contract.md): baseline generated files, metadata keys, and option vocabulary.
 - [Plan Command Drift Scope](plan-drift-scope.md): what `kickstart plan` covers, defers, and emits.
 - [Adoption Tiers](adoption-tiers.md): Level 1 conformant vs Level 2 managed, exit codes, and JSON shape.
+- [Backstage Export](backstage-export.md): derived/declared/passthrough field classes and re-export semantics.
 - [Install Binaries](../install-binaries.md): release asset names and install commands.
 - [Human Guide](../human-guide.md): supported project kinds, languages, runtimes, and CLI options.
 

--- a/docs/contracts/backstage-export.md
+++ b/docs/contracts/backstage-export.md
@@ -1,0 +1,45 @@
+# Backstage Export
+
+Checked: 2026-07-15
+
+`kickstart export backstage [REPO]` writes or refreshes `catalog-info.yaml`
+deterministically from `.kickstart/scaffold.json`. The mapping is the verb's;
+human judgment (real owner, lifecycle, description) belongs to the
+`backstage-catalog` skill layered on top.
+
+## Field classes
+
+- **Derived** — always regenerated, inside `# kickstart:begin/end` YAML
+  fences: `apiVersion`, `kind`, `metadata.name` (the manifest's project
+  name), `metadata.annotations.backstage.io/techdocs-ref: dir:.` when `docs/`
+  exists, and `metadata.tags` (service extensions plus execution models,
+  sorted). Systems additionally derive a `System` entity and, at creation,
+  one child `Component` per contained project found through the manifest's
+  `composition.child_manifest_globs`, each with `spec.system` set.
+- **Declared** — emitted once with anonymous, catalog-valid defaults, then
+  user-owned and never rewritten: `spec.type` (from the kind mapping:
+  service/worker → `service`, frontend → `website`, library → `library`,
+  cli → `tool`, system → `system`), `spec.lifecycle: experimental`, and
+  `spec.owner: group:default/unknown`. Backstage requires owner and
+  lifecycle to exist, so unknown values get sentinels, never empties. The
+  owner sentinel is one shared constant across the `--knowledge backstage`
+  system template, the exporter, and the skill.
+- **Passthrough** — everything else outside the fences (user-added keys,
+  descriptions, links) is never read for decisions and never rewritten.
+
+## Re-export semantics
+
+Repeated exports are idempotent: only fenced regions are spliced, so
+`export → export` is byte-stable and user edits outside fences always
+survive. An existing `catalog-info.yaml` with no kickstart fence is refused,
+never overwritten. Child Components are created with the file; children added
+to the system later are not auto-inserted on refresh (re-create or add by
+hand) — a documented v1 limit. `spec.type` is derived at creation and then
+preserved: a project-kind change requires re-creating the file.
+
+## Exit codes
+
+0 = exported cleanly (created/updated/unchanged); 1 = refused (unfenced or
+malformed existing file) or exported with validation warnings (a required
+entity line is missing after user edits); 2 = usage error (no repository or
+no usable manifest). Obsidian export is a planned follow-up.

--- a/docs/human-guide.md
+++ b/docs/human-guide.md
@@ -43,11 +43,22 @@ Other language/runtime/framework combinations fail loudly until their templates 
 
 ## Adopting Existing Repos
 
-`kickstart adopt REPO --check` reports which standard artifacts (scaffold
-manifest, `AGENTS.md`, `README.md`, a Makefile with a `check` target, the
-`docs/` areas, CI workflows) an existing repo is missing. It never writes;
-`--json` emits a machine-readable report. Exit codes: 0 complete, 1 gaps
-found, 2 usage error. Applying the standard automatically is planned.
+`kickstart adopt REPO --check` reports an existing repo against the standard
+at two levels: Level 1 conformant is the vendor-neutral artifact set
+(`AGENTS.md`, `README.md`, a Makefile with a `check` target, `.agents/skills/`,
+the `docs/` areas, CI workflows) with no manifest required; a
+`.kickstart/scaffold.json` claims Level 2 managed, which additionally needs
+the manifest to be valid and the managed docs fence-wrapped. It never writes;
+`--json` emits a machine-readable report. Exit codes: 0 claimed level
+satisfied, 1 gaps found, 2 usage error. Applying the standard automatically
+is planned. See [Adoption Tiers](contracts/adoption-tiers.md).
+
+`kickstart plan REPO` is the matching read-only drift check for managed docs:
+it re-renders them from the manifest and reports per-artifact status, with
+diffs shown only inside kickstart's owned fences — your content outside a
+fence is never compared or touched. `kickstart export backstage REPO` derives
+a `catalog-info.yaml` the same way (derived fields fenced and refreshed;
+owner and lifecycle are yours after the first emit).
 
 ## Library And CLI Options
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -23,7 +23,11 @@ from src.api import (
 )
 from src.cli.dispatch import ProjectCreators, dispatch_project_creation
 from src.generator.adoption import AdoptionTargetError, inspect_repo
-from src.generator.backstage_export import BackstageExportError, export_backstage
+from src.generator.backstage_export import (
+    BackstageExportError,
+    BackstageExportUsageError,
+    export_backstage,
+)
 from src.generator.docs_plan import DocsPlanTargetError, inspect_docs
 from src.cli.options import CreateCommandOptions, CreateOptions, ResolvedCreateArgs
 from src.cli.prompts import ConfirmReader, PromptReader, prompt_for_missing_args
@@ -103,10 +107,12 @@ def backstage(
     """
     try:
         result = export_backstage(path)
+    except BackstageExportUsageError as error:
+        print(f"[red]{escape(str(error))}[/]")
+        raise typer.Exit(code=2) from error
     except BackstageExportError as error:
-        message = str(error)
-        print(f"[red]{escape(message)}[/]")
-        raise typer.Exit(code=2 if "manifest" in message or "directory" in message else 1)
+        print(f"[red]{escape(str(error))}[/]")
+        raise typer.Exit(code=1) from error
 
     print(f"[bold]{result.action}[/] {escape(str(result.path))}")
     for issue in result.issues:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -23,6 +23,7 @@ from src.api import (
 )
 from src.cli.dispatch import ProjectCreators, dispatch_project_creation
 from src.generator.adoption import AdoptionTargetError, inspect_repo
+from src.generator.backstage_export import BackstageExportError, export_backstage
 from src.generator.docs_plan import DocsPlanTargetError, inspect_docs
 from src.cli.options import CreateCommandOptions, CreateOptions, ResolvedCreateArgs
 from src.cli.prompts import ConfirmReader, PromptReader, prompt_for_missing_args
@@ -82,6 +83,35 @@ def version() -> None:
 def upgrade() -> None:
     """Upgrade to the latest version."""
     check_for_update()
+
+
+export_app: typer.Typer = typer.Typer(help="Deterministic exporters derived from scaffold state.")
+app.add_typer(export_app, name="export")
+
+
+@export_app.command()
+def backstage(
+    path: Path = typer.Argument(Path("."), help="Repository to export"),
+) -> None:
+    """Write or refresh catalog-info.yaml from .kickstart/scaffold.json.
+
+    Derived fields live inside kickstart fences and are refreshed on every
+    export; spec.owner/lifecycle/type and everything else outside the fences
+    are user-owned and never rewritten. Exit codes: 0 = exported cleanly,
+    1 = exported with validation issues or refused (unfenced existing file),
+    2 = usage error (no repo or no usable manifest).
+    """
+    try:
+        result = export_backstage(path)
+    except BackstageExportError as error:
+        message = str(error)
+        print(f"[red]{escape(message)}[/]")
+        raise typer.Exit(code=2 if "manifest" in message or "directory" in message else 1)
+
+    print(f"[bold]{result.action}[/] {escape(str(result.path))}")
+    for issue in result.issues:
+        print(f"  [yellow]warning[/] {escape(issue)}")
+    raise typer.Exit(code=1 if result.issues else 0)
 
 
 @app.command()

--- a/src/generator/backstage_export.py
+++ b/src/generator/backstage_export.py
@@ -7,7 +7,8 @@
 - **derived** — apiVersion, kind, metadata (name, techdocs annotation, tags)
   and, for systems, the System entity and one child Component per contained
   project. Derived lines live inside ``# kickstart:begin/end`` YAML fences and
-  are refreshed on every export.
+  are refreshed on every export (including the fences of children that still
+  resolve; children added after creation are not auto-inserted).
 - **declared** — ``spec.type``, ``spec.lifecycle``, ``spec.owner`` (and any
   description the user adds): emitted once with anonymous, catalog-valid
   defaults, then user-owned. Backstage requires owner and lifecycle to exist,
@@ -22,6 +23,7 @@ idempotent and user edits outside fences always survive. An existing
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -37,9 +39,10 @@ from src.utils.errors import KickstartError, ManifestShapeError, MarkerError
 
 CATALOG_PATH = "catalog-info.yaml"
 
-# One anonymous-default constant for the system template, this exporter, and
-# the backstage-catalog skill. Backstage rejects entities without owner and
-# lifecycle, so unknown values get valid sentinels instead of empties.
+# One anonymous-default constant for the --knowledge backstage templates, this
+# exporter, and the backstage-catalog skill. Backstage rejects entities
+# without owner and lifecycle, so unknown values get valid sentinels instead
+# of empties.
 DEFAULT_OWNER = "group:default/unknown"
 DEFAULT_LIFECYCLE = "experimental"
 
@@ -55,11 +58,26 @@ _SPEC_TYPES: dict[str, str] = {
     "system": "system",
 }
 
-_REQUIRED_LINES = ("apiVersion:", "kind:", "name:", "type:", "lifecycle:", "owner:")
+_COMPONENT_REQUIRED_LINES = ("apiVersion:", "kind:", "name:", "type:", "lifecycle:", "owner:")
+_SYSTEM_REQUIRED_LINES = ("apiVersion:", "kind:", "name:", "owner:")
 
 
 class BackstageExportError(KickstartError):
-    """Raised when the repo cannot be exported (no manifest, unfenced file)."""
+    """Raised when an export is refused (unfenced or unreadable target)."""
+
+
+class BackstageExportUsageError(BackstageExportError):
+    """Raised when there is nothing usable to export from (exit-2 class)."""
+
+
+@dataclass(frozen=True)
+class _Child:
+    """One contained project resolved from the system's composition globs."""
+
+    name: str
+    fence_id: str
+    contract: ScaffoldContract
+    techdocs_ref: str | None
 
 
 @dataclass(frozen=True)
@@ -74,46 +92,54 @@ class BackstageExportResult:
 def export_backstage(root: Path) -> BackstageExportResult:
     """Write or refresh the repo's catalog entities, derived fields only."""
     if not root.is_dir():
-        raise BackstageExportError(f"export target '{root}' is not an existing directory")
+        raise BackstageExportUsageError(f"export target '{root}' is not an existing directory")
     resolved = root.resolve()
 
     try:
         manifest = load_parsed_manifest(resolved / MANIFEST_PATH)
         contract = ScaffoldContract.from_manifest(manifest)
+        name = _project_name(manifest)
     except ManifestShapeError as error:
-        raise BackstageExportError(f"cannot export from {MANIFEST_PATH}: {error}") from error
-    name = _project_name(manifest)
+        raise BackstageExportUsageError(f"cannot export from {MANIFEST_PATH}: {error}") from error
     has_docs = (resolved / "docs").is_dir()
+    children = _children(resolved, manifest) if contract.project_kind == "system" else ()
 
     target = resolved / CATALOG_PATH
-    if target.exists():
-        result = _refresh(target, contract, name, has_docs)
-    else:
-        result = _create(target, resolved, contract, manifest, name, has_docs)
-    return result
+    if target.exists() or target.is_symlink():
+        return _refresh(target, contract, name, has_docs, children)
+    return _create(target, contract, name, has_docs, children)
 
 
 def _create(
     target: Path,
-    resolved: Path,
     contract: ScaffoldContract,
-    manifest: ParsedManifest,
     name: str,
     has_docs: bool,
+    children: tuple[_Child, ...],
 ) -> BackstageExportResult:
     documents = [
-        fence(_ROOT_FENCE_ID, _component_derived_body(contract, name, has_docs), style="yaml")
+        fence(_ROOT_FENCE_ID, _component_derived_body(contract, name, "dir:." if has_docs else None), style="yaml")
         + _spec_block(contract, system=name if contract.project_kind == "system" else None)
     ]
     if contract.project_kind == "system":
         documents.append(fence(_SYSTEM_FENCE_ID, _system_derived_body(name), style="yaml") + _spec_block_system())
-        documents.extend(_child_documents(resolved, manifest, name))
+        documents.extend(
+            fence(child.fence_id, _component_derived_body(child.contract, child.name, child.techdocs_ref), style="yaml")
+            + _spec_block(child.contract, system=name)
+            for child in children
+        )
     content = "---\n".join(documents)
     target.write_text(content, encoding="utf-8")
     return BackstageExportResult(path=target, action="created", issues=_validation_issues(content))
 
 
-def _refresh(target: Path, contract: ScaffoldContract, name: str, has_docs: bool) -> BackstageExportResult:
+def _refresh(
+    target: Path,
+    contract: ScaffoldContract,
+    name: str,
+    has_docs: bool,
+    children: tuple[_Child, ...],
+) -> BackstageExportResult:
     try:
         text = target.read_text(encoding="utf-8")
     except (OSError, UnicodeDecodeError) as error:
@@ -121,18 +147,27 @@ def _refresh(target: Path, contract: ScaffoldContract, name: str, has_docs: bool
 
     try:
         region = find_fenced_region(text, _ROOT_FENCE_ID, style="yaml")
+        if region is None:
+            raise BackstageExportError(
+                f"existing {CATALOG_PATH} has no kickstart fence; refusing to modify a hand-written file"
+            )
+
+        updated = replace_fenced_region(
+            text, _ROOT_FENCE_ID, _component_derived_body(contract, name, "dir:." if has_docs else None), style="yaml"
+        )
+        if contract.project_kind == "system":
+            if find_fenced_region(updated, _SYSTEM_FENCE_ID, style="yaml"):
+                updated = replace_fenced_region(updated, _SYSTEM_FENCE_ID, _system_derived_body(name), style="yaml")
+            for child in children:
+                if find_fenced_region(updated, child.fence_id, style="yaml"):
+                    updated = replace_fenced_region(
+                        updated,
+                        child.fence_id,
+                        _component_derived_body(child.contract, child.name, child.techdocs_ref),
+                        style="yaml",
+                    )
     except MarkerError as error:
         raise BackstageExportError(f"existing {CATALOG_PATH} has malformed kickstart fences: {error}") from error
-    if region is None:
-        raise BackstageExportError(
-            f"existing {CATALOG_PATH} has no kickstart fence; refusing to modify a hand-written file"
-        )
-
-    updated = replace_fenced_region(
-        text, _ROOT_FENCE_ID, _component_derived_body(contract, name, has_docs), style="yaml"
-    )
-    if contract.project_kind == "system" and find_fenced_region(updated, _SYSTEM_FENCE_ID, style="yaml"):
-        updated = replace_fenced_region(updated, _SYSTEM_FENCE_ID, _system_derived_body(name), style="yaml")
 
     if updated == text:
         return BackstageExportResult(path=target, action="unchanged", issues=_validation_issues(text))
@@ -140,15 +175,15 @@ def _refresh(target: Path, contract: ScaffoldContract, name: str, has_docs: bool
     return BackstageExportResult(path=target, action="updated", issues=_validation_issues(updated))
 
 
-def _component_derived_body(contract: ScaffoldContract, name: str, has_docs: bool) -> str:
+def _component_derived_body(contract: ScaffoldContract, name: str, techdocs_ref: str | None) -> str:
     lines = [
         "apiVersion: backstage.io/v1alpha1",
         "kind: Component",
         "metadata:",
         f"  name: {name}",
     ]
-    if has_docs:
-        lines.extend(["  annotations:", "    backstage.io/techdocs-ref: dir:."])
+    if techdocs_ref is not None:
+        lines.extend(["  annotations:", f"    backstage.io/techdocs-ref: {techdocs_ref}"])
     tags = _tags(contract)
     if tags:
         lines.append("  tags:")
@@ -183,17 +218,21 @@ def _spec_block_system() -> str:
     return "\n".join(["spec:", f"  owner: {DEFAULT_OWNER}"]) + "\n"
 
 
-def _child_documents(resolved: Path, manifest: ParsedManifest, system_name: str) -> list[str]:
-    """Creation-time Component docs for contained projects, one per child manifest."""
+def _children(resolved: Path, manifest: ParsedManifest) -> tuple[_Child, ...]:
+    """Contained projects resolved from the system's composition globs.
+
+    Children that cannot be interpreted (unparseable manifest, missing name)
+    are skipped rather than aborting the export.
+    """
     composition = manifest.get("composition")
     if not isinstance(composition, dict):
-        return []
+        return ()
     globs = composition.get("child_manifest_globs")
     if not isinstance(globs, list):
-        return []
+        return ()
 
-    documents: list[str] = []
-    seen: set[str] = set()
+    children: list[_Child] = []
+    seen_fence_ids: set[str] = set()
     for pattern in globs:
         if not isinstance(pattern, str):
             continue
@@ -201,19 +240,28 @@ def _child_documents(resolved: Path, manifest: ParsedManifest, system_name: str)
             try:
                 child_manifest = load_parsed_manifest(child_manifest_path)
                 child_contract = ScaffoldContract.from_manifest(child_manifest)
+                child_name = _project_name(child_manifest)
             except ManifestShapeError:
                 continue
-            child_name = _project_name(child_manifest)
-            if child_name in seen:
+            fence_id = f"catalog-child-{_fence_safe(child_name)}"
+            if fence_id in seen_fence_ids:
                 continue
-            seen.add(child_name)
+            seen_fence_ids.add(fence_id)
             child_root = child_manifest_path.parent.parent
-            body = _component_derived_body(child_contract, child_name, (child_root / "docs").is_dir())
-            documents.append(
-                fence(f"catalog-child-{child_name}", body, style="yaml")
-                + _spec_block(child_contract, system=system_name)
+            techdocs_ref: str | None = None
+            if (child_root / "docs").is_dir():
+                # Entities in the root catalog file resolve relative paths
+                # against the root, so each child needs its own subpath.
+                techdocs_ref = f"dir:./{child_root.relative_to(resolved).as_posix()}"
+            children.append(
+                _Child(name=child_name, fence_id=fence_id, contract=child_contract, techdocs_ref=techdocs_ref)
             )
-    return documents
+    return tuple(children)
+
+
+def _fence_safe(name: str) -> str:
+    """Map a project name onto the marker id alphabet (underscores allowed in names)."""
+    return re.sub(r"[^a-z0-9-]", "-", name)
 
 
 def _project_name(manifest: ParsedManifest) -> str:
@@ -222,7 +270,7 @@ def _project_name(manifest: ParsedManifest) -> str:
         name = project.get("name")
         if isinstance(name, str) and name:
             return name
-    raise BackstageExportError("manifest has no project.name to derive the entity name from")
+    raise ManifestShapeError("manifest has no project.name to derive the entity name from")
 
 
 def _tags(contract: ScaffoldContract) -> list[str]:
@@ -234,9 +282,11 @@ def _tags(contract: ScaffoldContract) -> list[str]:
 
 
 def _validation_issues(content: str) -> tuple[str, ...]:
-    """Line-presence validation for the fields Backstage requires."""
+    """Per-entity line-presence validation for the fields Backstage requires."""
     issues: list[str] = []
-    for required in _REQUIRED_LINES:
-        if not any(line.strip().startswith(required) for line in content.splitlines()):
-            issues.append(f"missing required field line: {required}")
+    for index, document in enumerate(content.split("\n---\n")):
+        required_lines = _SYSTEM_REQUIRED_LINES if "kind: System" in document else _COMPONENT_REQUIRED_LINES
+        for required in required_lines:
+            if not any(line.strip().startswith(required) for line in document.splitlines()):
+                issues.append(f"entity {index + 1} missing required field line: {required}")
     return tuple(issues)

--- a/src/generator/backstage_export.py
+++ b/src/generator/backstage_export.py
@@ -1,0 +1,242 @@
+"""Deterministic Backstage catalog export derived from scaffold state.
+
+`kickstart export backstage` emits `catalog-info.yaml` from
+`.kickstart/scaffold.json` with three field classes
+(``docs/contracts/backstage-export.md``):
+
+- **derived** — apiVersion, kind, metadata (name, techdocs annotation, tags)
+  and, for systems, the System entity and one child Component per contained
+  project. Derived lines live inside ``# kickstart:begin/end`` YAML fences and
+  are refreshed on every export.
+- **declared** — ``spec.type``, ``spec.lifecycle``, ``spec.owner`` (and any
+  description the user adds): emitted once with anonymous, catalog-valid
+  defaults, then user-owned. Backstage requires owner and lifecycle to exist,
+  so the defaults are sentinels, never empty values.
+- **passthrough** — everything else outside the fences is never read for
+  decisions and never rewritten.
+
+Re-export replaces only the fenced regions, so repeated exports are
+idempotent and user edits outside fences always survive. An existing
+`catalog-info.yaml` without a kickstart fence is refused, never overwritten.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from src.generator.markers import fence, find_fenced_region, replace_fenced_region
+from src.generator.scaffold_contract import (
+    MANIFEST_PATH,
+    ParsedManifest,
+    ScaffoldContract,
+    load_parsed_manifest,
+)
+from src.utils.errors import KickstartError, ManifestShapeError, MarkerError
+
+CATALOG_PATH = "catalog-info.yaml"
+
+# One anonymous-default constant for the system template, this exporter, and
+# the backstage-catalog skill. Backstage rejects entities without owner and
+# lifecycle, so unknown values get valid sentinels instead of empties.
+DEFAULT_OWNER = "group:default/unknown"
+DEFAULT_LIFECYCLE = "experimental"
+
+_ROOT_FENCE_ID = "catalog-derived"
+_SYSTEM_FENCE_ID = "catalog-system"
+
+_SPEC_TYPES: dict[str, str] = {
+    "service": "service",
+    "worker": "service",
+    "frontend": "website",
+    "library": "library",
+    "cli": "tool",
+    "system": "system",
+}
+
+_REQUIRED_LINES = ("apiVersion:", "kind:", "name:", "type:", "lifecycle:", "owner:")
+
+
+class BackstageExportError(KickstartError):
+    """Raised when the repo cannot be exported (no manifest, unfenced file)."""
+
+
+@dataclass(frozen=True)
+class BackstageExportResult:
+    """Outcome of one export run."""
+
+    path: Path
+    action: Literal["created", "updated", "unchanged"]
+    issues: tuple[str, ...] = ()
+
+
+def export_backstage(root: Path) -> BackstageExportResult:
+    """Write or refresh the repo's catalog entities, derived fields only."""
+    if not root.is_dir():
+        raise BackstageExportError(f"export target '{root}' is not an existing directory")
+    resolved = root.resolve()
+
+    try:
+        manifest = load_parsed_manifest(resolved / MANIFEST_PATH)
+        contract = ScaffoldContract.from_manifest(manifest)
+    except ManifestShapeError as error:
+        raise BackstageExportError(f"cannot export from {MANIFEST_PATH}: {error}") from error
+    name = _project_name(manifest)
+    has_docs = (resolved / "docs").is_dir()
+
+    target = resolved / CATALOG_PATH
+    if target.exists():
+        result = _refresh(target, contract, name, has_docs)
+    else:
+        result = _create(target, resolved, contract, manifest, name, has_docs)
+    return result
+
+
+def _create(
+    target: Path,
+    resolved: Path,
+    contract: ScaffoldContract,
+    manifest: ParsedManifest,
+    name: str,
+    has_docs: bool,
+) -> BackstageExportResult:
+    documents = [
+        fence(_ROOT_FENCE_ID, _component_derived_body(contract, name, has_docs), style="yaml")
+        + _spec_block(contract, system=name if contract.project_kind == "system" else None)
+    ]
+    if contract.project_kind == "system":
+        documents.append(fence(_SYSTEM_FENCE_ID, _system_derived_body(name), style="yaml") + _spec_block_system())
+        documents.extend(_child_documents(resolved, manifest, name))
+    content = "---\n".join(documents)
+    target.write_text(content, encoding="utf-8")
+    return BackstageExportResult(path=target, action="created", issues=_validation_issues(content))
+
+
+def _refresh(target: Path, contract: ScaffoldContract, name: str, has_docs: bool) -> BackstageExportResult:
+    try:
+        text = target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise BackstageExportError(f"cannot read existing {CATALOG_PATH}: {error}") from error
+
+    try:
+        region = find_fenced_region(text, _ROOT_FENCE_ID, style="yaml")
+    except MarkerError as error:
+        raise BackstageExportError(f"existing {CATALOG_PATH} has malformed kickstart fences: {error}") from error
+    if region is None:
+        raise BackstageExportError(
+            f"existing {CATALOG_PATH} has no kickstart fence; refusing to modify a hand-written file"
+        )
+
+    updated = replace_fenced_region(
+        text, _ROOT_FENCE_ID, _component_derived_body(contract, name, has_docs), style="yaml"
+    )
+    if contract.project_kind == "system" and find_fenced_region(updated, _SYSTEM_FENCE_ID, style="yaml"):
+        updated = replace_fenced_region(updated, _SYSTEM_FENCE_ID, _system_derived_body(name), style="yaml")
+
+    if updated == text:
+        return BackstageExportResult(path=target, action="unchanged", issues=_validation_issues(text))
+    target.write_text(updated, encoding="utf-8")
+    return BackstageExportResult(path=target, action="updated", issues=_validation_issues(updated))
+
+
+def _component_derived_body(contract: ScaffoldContract, name: str, has_docs: bool) -> str:
+    lines = [
+        "apiVersion: backstage.io/v1alpha1",
+        "kind: Component",
+        "metadata:",
+        f"  name: {name}",
+    ]
+    if has_docs:
+        lines.extend(["  annotations:", "    backstage.io/techdocs-ref: dir:."])
+    tags = _tags(contract)
+    if tags:
+        lines.append("  tags:")
+        lines.extend(f"    - {tag}" for tag in tags)
+    return "\n".join(lines) + "\n"
+
+
+def _system_derived_body(name: str) -> str:
+    return "\n".join(
+        [
+            "apiVersion: backstage.io/v1alpha1",
+            "kind: System",
+            "metadata:",
+            f"  name: {name}",
+        ]
+    ) + "\n"
+
+
+def _spec_block(contract: ScaffoldContract, system: str | None = None) -> str:
+    lines = [
+        "spec:",
+        f"  type: {_SPEC_TYPES[contract.project_kind]}",
+        f"  lifecycle: {DEFAULT_LIFECYCLE}",
+        f"  owner: {DEFAULT_OWNER}",
+    ]
+    if system is not None:
+        lines.append(f"  system: {system}")
+    return "\n".join(lines) + "\n"
+
+
+def _spec_block_system() -> str:
+    return "\n".join(["spec:", f"  owner: {DEFAULT_OWNER}"]) + "\n"
+
+
+def _child_documents(resolved: Path, manifest: ParsedManifest, system_name: str) -> list[str]:
+    """Creation-time Component docs for contained projects, one per child manifest."""
+    composition = manifest.get("composition")
+    if not isinstance(composition, dict):
+        return []
+    globs = composition.get("child_manifest_globs")
+    if not isinstance(globs, list):
+        return []
+
+    documents: list[str] = []
+    seen: set[str] = set()
+    for pattern in globs:
+        if not isinstance(pattern, str):
+            continue
+        for child_manifest_path in sorted(resolved.glob(pattern)):
+            try:
+                child_manifest = load_parsed_manifest(child_manifest_path)
+                child_contract = ScaffoldContract.from_manifest(child_manifest)
+            except ManifestShapeError:
+                continue
+            child_name = _project_name(child_manifest)
+            if child_name in seen:
+                continue
+            seen.add(child_name)
+            child_root = child_manifest_path.parent.parent
+            body = _component_derived_body(child_contract, child_name, (child_root / "docs").is_dir())
+            documents.append(
+                fence(f"catalog-child-{child_name}", body, style="yaml")
+                + _spec_block(child_contract, system=system_name)
+            )
+    return documents
+
+
+def _project_name(manifest: ParsedManifest) -> str:
+    project = manifest.get("project")
+    if isinstance(project, dict):
+        name = project.get("name")
+        if isinstance(name, str) and name:
+            return name
+    raise BackstageExportError("manifest has no project.name to derive the entity name from")
+
+
+def _tags(contract: ScaffoldContract) -> list[str]:
+    extensions = contract.service_extensions
+    extension_values = [
+        value for value in (extensions.database, extensions.cache, extensions.auth) if value is not None
+    ]
+    return sorted({*extension_values, *contract.execution_models})
+
+
+def _validation_issues(content: str) -> tuple[str, ...]:
+    """Line-presence validation for the fields Backstage requires."""
+    issues: list[str] = []
+    for required in _REQUIRED_LINES:
+        if not any(line.strip().startswith(required) for line in content.splitlines()):
+            issues.append(f"missing required field line: {required}")
+    return tuple(issues)

--- a/src/generator/backstage_export.py
+++ b/src/generator/backstage_export.py
@@ -61,6 +61,44 @@ _SPEC_TYPES: dict[str, str] = {
 _COMPONENT_REQUIRED_LINES = ("apiVersion:", "kind:", "name:", "type:", "lifecycle:", "owner:")
 _SYSTEM_REQUIRED_LINES = ("apiVersion:", "kind:", "name:", "owner:")
 
+# Conservative plain-scalar shape: values matching this parse back as the
+# same string under YAML. ':' is only allowed when followed by another safe
+# character (YAML treats ':' as special only before whitespace/end), which
+# keeps `group:default/unknown` and `dir:./apps/x` unquoted. Reserved words
+# and leading digits are quoted so `null` or `123` stay strings.
+_PLAIN_YAML_SAFE = re.compile(r"[A-Za-z][A-Za-z0-9._/-]*(?::[A-Za-z0-9._/-]+)*")
+_YAML_RESERVED = frozenset(
+    {"null", "~", "true", "false", "yes", "no", "on", "off", "y", "n"}
+)
+
+# Backstage entity-name contract (metadata.name): the API rejects anything
+# else, so validate before writing instead of emitting a doomed entity.
+_BACKSTAGE_NAME = re.compile(r"[A-Za-z0-9][-A-Za-z0-9_.]*")
+_BACKSTAGE_NAME_MAX_LENGTH = 63
+
+
+def _yaml_string(value: str) -> str:
+    """Render a string as a YAML scalar that always parses back as a string."""
+    if _PLAIN_YAML_SAFE.fullmatch(value) and value.lower() not in _YAML_RESERVED:
+        return value
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return f'"{escaped}"'
+
+
+def _backstage_name_issue(name: str) -> str:
+    """Return why a name violates the Backstage metadata.name contract, or ''."""
+    if len(name) > _BACKSTAGE_NAME_MAX_LENGTH:
+        return f"'{name}' is longer than the {_BACKSTAGE_NAME_MAX_LENGTH}-character Backstage limit"
+    if _BACKSTAGE_NAME.fullmatch(name) is None:
+        return f"'{name}' is not a valid Backstage entity name"
+    return ""
+
 
 class BackstageExportError(KickstartError):
     """Raised when an export is refused (unfenced or unreadable target)."""
@@ -101,6 +139,9 @@ def export_backstage(root: Path) -> BackstageExportResult:
         name = _project_name(manifest)
     except ManifestShapeError as error:
         raise BackstageExportUsageError(f"cannot export from {MANIFEST_PATH}: {error}") from error
+    name_issue = _backstage_name_issue(name)
+    if name_issue:
+        raise BackstageExportUsageError(f"cannot export {MANIFEST_PATH}: {name_issue}")
     has_docs = (resolved / "docs").is_dir()
     children = _children(resolved, manifest) if contract.project_kind == "system" else ()
 
@@ -180,14 +221,14 @@ def _component_derived_body(contract: ScaffoldContract, name: str, techdocs_ref:
         "apiVersion: backstage.io/v1alpha1",
         "kind: Component",
         "metadata:",
-        f"  name: {name}",
+        f"  name: {_yaml_string(name)}",
     ]
     if techdocs_ref is not None:
-        lines.extend(["  annotations:", f"    backstage.io/techdocs-ref: {techdocs_ref}"])
+        lines.extend(["  annotations:", f"    backstage.io/techdocs-ref: {_yaml_string(techdocs_ref)}"])
     tags = _tags(contract)
     if tags:
         lines.append("  tags:")
-        lines.extend(f"    - {tag}" for tag in tags)
+        lines.extend(f"    - {_yaml_string(tag)}" for tag in tags)
     return "\n".join(lines) + "\n"
 
 
@@ -197,7 +238,7 @@ def _system_derived_body(name: str) -> str:
             "apiVersion: backstage.io/v1alpha1",
             "kind: System",
             "metadata:",
-            f"  name: {name}",
+            f"  name: {_yaml_string(name)}",
         ]
     ) + "\n"
 
@@ -210,7 +251,7 @@ def _spec_block(contract: ScaffoldContract, system: str | None = None) -> str:
         f"  owner: {DEFAULT_OWNER}",
     ]
     if system is not None:
-        lines.append(f"  system: {system}")
+        lines.append(f"  system: {_yaml_string(system)}")
     return "\n".join(lines) + "\n"
 
 
@@ -222,7 +263,9 @@ def _children(resolved: Path, manifest: ParsedManifest) -> tuple[_Child, ...]:
     """Contained projects resolved from the system's composition globs.
 
     Children that cannot be interpreted (unparseable manifest, missing name)
-    are skipped rather than aborting the export.
+    are skipped rather than aborting the export. Children that would export
+    wrongly — an invalid Backstage name, or two names colliding onto one
+    fence id — abort loudly instead of silently dropping an entity.
     """
     composition = manifest.get("composition")
     if not isinstance(composition, dict):
@@ -232,7 +275,7 @@ def _children(resolved: Path, manifest: ParsedManifest) -> tuple[_Child, ...]:
         return ()
 
     children: list[_Child] = []
-    seen_fence_ids: set[str] = set()
+    fence_id_owners: dict[str, str] = {}
     for pattern in globs:
         if not isinstance(pattern, str):
             continue
@@ -243,10 +286,22 @@ def _children(resolved: Path, manifest: ParsedManifest) -> tuple[_Child, ...]:
                 child_name = _project_name(child_manifest)
             except ManifestShapeError:
                 continue
+            name_issue = _backstage_name_issue(child_name)
+            if name_issue:
+                raise BackstageExportError(f"contained project cannot be exported: {name_issue}")
             fence_id = f"catalog-child-{_fence_safe(child_name)}"
-            if fence_id in seen_fence_ids:
+            owner = fence_id_owners.get(fence_id)
+            if owner == child_name:
+                # The same child discovered through overlapping globs.
                 continue
-            seen_fence_ids.add(fence_id)
+            if owner is not None:
+                # Silently dropping an entity would break the promised
+                # one-Component-per-child mapping; fail loudly instead.
+                raise BackstageExportError(
+                    f"contained projects '{owner}' and '{child_name}' both map to fence id "
+                    f"'{fence_id}'; rename one so every child keeps its own catalog entity"
+                )
+            fence_id_owners[fence_id] = child_name
             child_root = child_manifest_path.parent.parent
             techdocs_ref: str | None = None
             if (child_root / "docs").is_dir():

--- a/src/templates/monorepo/backstage_template.yaml
+++ b/src/templates/monorepo/backstage_template.yaml
@@ -5,7 +5,7 @@ metadata:
   title: {{ monorepo_name }} Service
   description: Create a service that follows the {{ monorepo_name }} workspace conventions.
 spec:
-  owner: group:default/platform
+  owner: group:default/unknown
   type: service
   parameters:
     - title: Service

--- a/src/templates/monorepo/catalog-info.yaml
+++ b/src/templates/monorepo/catalog-info.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   type: service
   lifecycle: experimental
-  owner: group:default/platform
+  owner: group:default/unknown
   system: {{ monorepo_name }}

--- a/tests/integration/test_export_command.py
+++ b/tests/integration/test_export_command.py
@@ -1,0 +1,51 @@
+"""kickstart export backstage end-to-end on real generator output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.integration.conftest import KickstartRunner
+
+
+def test_export_backstage_round_trip(
+    kickstart_run: KickstartRunner, repo_root: Path, tmp_path: Path
+) -> None:
+    completed = kickstart_run(
+        "create",
+        "service",
+        "exported-api",
+        "--lang",
+        "python",
+        "--database",
+        "postgres",
+        "--root",
+        str(tmp_path),
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    project = tmp_path / "exported-api"
+
+    created = kickstart_run("export", "backstage", str(project), cwd=repo_root, capture_output=True, text=True)
+    catalog = project / "catalog-info.yaml"
+    first = catalog.read_text(encoding="utf-8")
+
+    rerun = kickstart_run("export", "backstage", str(project), cwd=repo_root, capture_output=True, text=True)
+    second = catalog.read_text(encoding="utf-8")
+
+    catalog.write_text(
+        first.replace("owner: group:default/unknown", "owner: group:default/team-api"), encoding="utf-8"
+    )
+    after_edit = kickstart_run(
+        "export", "backstage", str(project), cwd=repo_root, capture_output=True, text=True
+    )
+
+    assert created.returncode == 0, created.stdout + created.stderr
+    assert "created" in created.stdout
+    assert "postgres" in first and "name: exported-api" in first
+    assert rerun.returncode == 0
+    assert "unchanged" in rerun.stdout
+    assert first == second
+    assert after_edit.returncode == 0
+    assert "owner: group:default/team-api" in catalog.read_text(encoding="utf-8")

--- a/tests/unit/generator/test_backstage_export.py
+++ b/tests/unit/generator/test_backstage_export.py
@@ -221,10 +221,15 @@ def test_nameless_child_is_skipped_not_fatal(tmp_path: Path) -> None:
 
 
 def test_template_owner_default_matches_exporter_constant() -> None:
-    template = Path("src/templates/monorepo/catalog-info.yaml").read_text(encoding="utf-8")
+    templates = (
+        Path("src/templates/monorepo/catalog-info.yaml"),
+        Path("src/templates/monorepo/backstage_template.yaml"),
+    )
+    for template_path in templates:
+        template = template_path.read_text(encoding="utf-8")
 
-    assert DEFAULT_OWNER in template
-    assert "group:default/platform" not in template
+        assert DEFAULT_OWNER in template, template_path
+        assert "group:default/platform" not in template, template_path
 
 
 def test_export_result_reports_missing_required_lines(tmp_path: Path) -> None:

--- a/tests/unit/generator/test_backstage_export.py
+++ b/tests/unit/generator/test_backstage_export.py
@@ -1,0 +1,179 @@
+"""Deterministic Backstage export: field classes, idempotence, fail-closed."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.generator.backstage_export import (
+    CATALOG_PATH,
+    DEFAULT_LIFECYCLE,
+    DEFAULT_OWNER,
+    BackstageExportError,
+    export_backstage,
+)
+from src.generator.scaffold_contract import MANIFEST_PATH, ScaffoldArtifacts, ScaffoldContract, ScaffoldServiceExtensions
+
+
+def _write_manifest(root: Path, contract: ScaffoldContract, name: str) -> None:
+    (root / ".kickstart").mkdir(parents=True, exist_ok=True)
+    (root / MANIFEST_PATH).write_text(contract.manifest_json(name), encoding="utf-8")
+
+
+def _service_repo(root: Path) -> None:
+    contract = ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+        artifacts=ScaffoldArtifacts(image="dockerfile"),
+        service_extensions=ScaffoldServiceExtensions(database="postgres"),
+    )
+    _write_manifest(root, contract, "demo-api")
+    (root / "docs").mkdir()
+
+
+def test_fresh_export_derives_component_with_defaults(tmp_path: Path) -> None:
+    _service_repo(tmp_path)
+
+    result = export_backstage(tmp_path)
+    content = (tmp_path / CATALOG_PATH).read_text(encoding="utf-8")
+
+    assert result.action == "created"
+    assert result.issues == ()
+    assert content.startswith("# kickstart:begin catalog-derived\n")
+    assert "kind: Component" in content
+    assert "  name: demo-api" in content
+    assert "backstage.io/techdocs-ref: dir:." in content
+    assert "    - container\n    - postgres" in content
+    assert f"  lifecycle: {DEFAULT_LIFECYCLE}" in content
+    assert f"  owner: {DEFAULT_OWNER}" in content
+    assert "  type: service" in content
+
+
+def test_export_is_idempotent(tmp_path: Path) -> None:
+    _service_repo(tmp_path)
+
+    export_backstage(tmp_path)
+    first = (tmp_path / CATALOG_PATH).read_bytes()
+    result = export_backstage(tmp_path)
+    second = (tmp_path / CATALOG_PATH).read_bytes()
+
+    assert result.action == "unchanged"
+    assert first == second
+
+
+def test_declared_and_passthrough_survive_reexport(tmp_path: Path) -> None:
+    _service_repo(tmp_path)
+    export_backstage(tmp_path)
+    target = tmp_path / CATALOG_PATH
+
+    edited = target.read_text(encoding="utf-8")
+    edited = edited.replace(f"  owner: {DEFAULT_OWNER}", "  owner: group:default/platform-team")
+    edited += "  custom/annotation: kept\n"
+    # An edit inside the fence must be reverted by the next export.
+    edited = edited.replace("  name: demo-api", "  name: hand-renamed")
+    target.write_text(edited, encoding="utf-8")
+
+    result = export_backstage(tmp_path)
+    content = target.read_text(encoding="utf-8")
+
+    assert result.action == "updated"
+    assert "  owner: group:default/platform-team" in content
+    assert "  custom/annotation: kept" in content
+    assert "  name: demo-api" in content
+    assert "hand-renamed" not in content
+
+
+def test_unfenced_existing_file_is_refused(tmp_path: Path) -> None:
+    _service_repo(tmp_path)
+    (tmp_path / CATALOG_PATH).write_text("kind: Component\n", encoding="utf-8")
+
+    with pytest.raises(BackstageExportError):
+        export_backstage(tmp_path)
+
+
+def test_missing_manifest_is_an_export_error(tmp_path: Path) -> None:
+    with pytest.raises(BackstageExportError):
+        export_backstage(tmp_path)
+
+
+def test_kind_type_mapping(tmp_path: Path) -> None:
+    cases = {
+        "worker": "service",
+        "frontend": "website",
+        "library": "library",
+        "cli": "tool",
+    }
+    for kind, expected_type in cases.items():
+        root = tmp_path / kind
+        root.mkdir()
+        contract = ScaffoldContract(
+            project_kind=kind,  # type: ignore[arg-type]
+            execution_models=("cli",),
+            runtime_platforms=("local",),
+        )
+        _write_manifest(root, contract, f"demo-{kind}")
+
+        export_backstage(root)
+
+        content = (root / CATALOG_PATH).read_text(encoding="utf-8")
+        assert f"  type: {expected_type}" in content, kind
+
+
+def test_system_export_emits_system_and_children(tmp_path: Path) -> None:
+    system_contract = ScaffoldContract(
+        project_kind="system",
+        execution_models=("container",),
+        runtime_platforms=("kubernetes",),
+        repo_layout="monorepo",
+    )
+    _write_manifest(tmp_path, system_contract, "demo-sys")
+    child_contract = ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+    )
+    child_root = tmp_path / "services" / "api"
+    child_root.mkdir(parents=True)
+    _write_manifest(child_root, child_contract, "api")
+
+    result = export_backstage(tmp_path)
+    content = (tmp_path / CATALOG_PATH).read_text(encoding="utf-8")
+
+    assert result.action == "created"
+    assert "kind: System" in content
+    assert "# kickstart:begin catalog-child-api" in content
+    assert "  system: demo-sys" in content
+    assert content.count("---\n") == 2
+
+
+def test_template_owner_default_matches_exporter_constant() -> None:
+    template = Path("src/templates/monorepo/catalog-info.yaml").read_text(encoding="utf-8")
+
+    assert DEFAULT_OWNER in template
+    assert "group:default/platform" not in template
+
+
+def test_export_result_reports_missing_required_lines(tmp_path: Path) -> None:
+    _service_repo(tmp_path)
+    export_backstage(tmp_path)
+    target = tmp_path / CATALOG_PATH
+    target.write_text(
+        target.read_text(encoding="utf-8").replace(f"  owner: {DEFAULT_OWNER}\n", ""), encoding="utf-8"
+    )
+
+    result = export_backstage(tmp_path)
+
+    assert any("owner:" in issue for issue in result.issues)
+
+
+def test_manifest_name_round_trips_from_generated_manifest(tmp_path: Path) -> None:
+    contract = ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+    )
+    _write_manifest(tmp_path, contract, "named-thing")
+    manifest = json.loads((tmp_path / MANIFEST_PATH).read_text(encoding="utf-8"))
+
+    assert manifest["project"]["name"] == "named-thing"

--- a/tests/unit/generator/test_backstage_export.py
+++ b/tests/unit/generator/test_backstage_export.py
@@ -255,3 +255,52 @@ def test_manifest_name_round_trips_from_generated_manifest(tmp_path: Path) -> No
     manifest = json.loads((tmp_path / MANIFEST_PATH).read_text(encoding="utf-8"))
 
     assert manifest["project"]["name"] == "named-thing"
+
+
+def test_yaml_reserved_name_is_quoted_as_a_string(tmp_path: Path) -> None:
+    contract = ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+    )
+    _write_manifest(tmp_path, contract, "null")
+
+    export_backstage(tmp_path)
+    content = (tmp_path / CATALOG_PATH).read_text(encoding="utf-8")
+
+    assert '  name: "null"' in content
+    assert "\n  name: null\n" not in content
+
+
+def test_colliding_child_fence_ids_fail_instead_of_dropping(tmp_path: Path) -> None:
+    system_contract = ScaffoldContract(
+        project_kind="system",
+        execution_models=("container",),
+        runtime_platforms=("kubernetes",),
+        repo_layout="monorepo",
+    )
+    _write_manifest(tmp_path, system_contract, "demo-sys")
+    child_contract = ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+    )
+    for child_name in ("foo-bar", "foo_bar"):
+        child_root = tmp_path / "services" / child_name
+        child_root.mkdir(parents=True)
+        _write_manifest(child_root, child_contract, child_name)
+
+    with pytest.raises(BackstageExportError, match="foo-bar.*foo_bar|foo_bar.*foo-bar"):
+        export_backstage(tmp_path)
+
+
+def test_name_beyond_backstage_limit_is_refused(tmp_path: Path) -> None:
+    contract = ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+    )
+    _write_manifest(tmp_path, contract, "a" * 64)
+
+    with pytest.raises(BackstageExportError, match="63-character"):
+        export_backstage(tmp_path)

--- a/tests/unit/generator/test_backstage_export.py
+++ b/tests/unit/generator/test_backstage_export.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -12,7 +13,13 @@ from src.generator.backstage_export import (
     BackstageExportError,
     export_backstage,
 )
-from src.generator.scaffold_contract import MANIFEST_PATH, ScaffoldArtifacts, ScaffoldContract, ScaffoldServiceExtensions
+from src.generator.scaffold_contract import (
+    MANIFEST_PATH,
+    ProjectKind,
+    ScaffoldArtifacts,
+    ScaffoldContract,
+    ScaffoldServiceExtensions,
+)
 
 
 def _write_manifest(root: Path, contract: ScaffoldContract, name: str) -> None:
@@ -108,7 +115,7 @@ def test_kind_type_mapping(tmp_path: Path) -> None:
         root = tmp_path / kind
         root.mkdir()
         contract = ScaffoldContract(
-            project_kind=kind,  # type: ignore[arg-type]
+            project_kind=cast(ProjectKind, kind),
             execution_models=("cli",),
             runtime_platforms=("local",),
         )
@@ -145,6 +152,72 @@ def test_system_export_emits_system_and_children(tmp_path: Path) -> None:
     assert "# kickstart:begin catalog-child-api" in content
     assert "  system: demo-sys" in content
     assert content.count("---\n") == 2
+    # The child's TechDocs source must point at its own subtree, not the root.
+    (tmp_path / "services" / "api" / "docs").mkdir()
+    refreshed = export_backstage(tmp_path)
+    content = (tmp_path / CATALOG_PATH).read_text(encoding="utf-8")
+    assert refreshed.action == "updated"
+    assert "backstage.io/techdocs-ref: dir:./services/api" in content
+
+
+def test_child_fences_refresh_and_underscore_names_are_safe(tmp_path: Path) -> None:
+    system_contract = ScaffoldContract(
+        project_kind="system",
+        execution_models=("container",),
+        runtime_platforms=("kubernetes",),
+        repo_layout="monorepo",
+    )
+    _write_manifest(tmp_path, system_contract, "demo-sys")
+    child_contract = ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+    )
+    child_root = tmp_path / "services" / "data_api"
+    child_root.mkdir(parents=True)
+    _write_manifest(child_root, child_contract, "data_api")
+
+    export_backstage(tmp_path)
+    content = (tmp_path / CATALOG_PATH).read_text(encoding="utf-8")
+    assert "# kickstart:begin catalog-child-data-api" in content
+    assert "  name: data_api" in content
+
+    # A derived change in the child (new extension tag) refreshes its fence.
+    richer_child = ScaffoldContract(
+        project_kind="service",
+        execution_models=("container",),
+        runtime_platforms=("local",),
+        service_extensions=ScaffoldServiceExtensions(database="postgres"),
+    )
+    _write_manifest(child_root, richer_child, "data_api")
+    result = export_backstage(tmp_path)
+    content = (tmp_path / CATALOG_PATH).read_text(encoding="utf-8")
+    assert result.action == "updated"
+    assert "    - postgres" in content
+
+
+def test_nameless_child_is_skipped_not_fatal(tmp_path: Path) -> None:
+    system_contract = ScaffoldContract(
+        project_kind="system",
+        execution_models=("container",),
+        runtime_platforms=("kubernetes",),
+        repo_layout="monorepo",
+    )
+    _write_manifest(tmp_path, system_contract, "demo-sys")
+    broken_child = tmp_path / "services" / "mystery" / ".kickstart"
+    broken_child.mkdir(parents=True)
+    manifest = json.loads(
+        ScaffoldContract(
+            project_kind="service", execution_models=("container",), runtime_platforms=("local",)
+        ).manifest_json("mystery")
+    )
+    del manifest["project"]["name"]
+    (broken_child / "scaffold.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = export_backstage(tmp_path)
+
+    assert result.action == "created"
+    assert "catalog-child" not in (tmp_path / CATALOG_PATH).read_text(encoding="utf-8")
 
 
 def test_template_owner_default_matches_exporter_constant() -> None:
@@ -164,7 +237,7 @@ def test_export_result_reports_missing_required_lines(tmp_path: Path) -> None:
 
     result = export_backstage(tmp_path)
 
-    assert any("owner:" in issue for issue in result.issues)
+    assert any("owner:" in issue and "entity 1" in issue for issue in result.issues)
 
 
 def test_manifest_name_round_trips_from_generated_manifest(tmp_path: Path) -> None:


### PR DESCRIPTION
## Primary changes

Stacked PR 6/6 (base: `docs-interface/05-tiered-adopt`, PR #92). The Backstage mapping graduates from LLM-executed skill instructions to a deterministic verb, with the never-clobber field-class model:

- **Derived** (inside `# kickstart:begin/end` YAML fences, refreshed every export): `apiVersion`, `kind`, `metadata.name`/techdocs annotation/`tags` (extensions + execution models, sorted); systems additionally derive a `System` entity and creation-time child `Component`s discovered through `composition.child_manifest_globs`, each with `spec.system`.
- **Declared** (emitted once with anonymous catalog-valid sentinels, then user-owned): `spec.type` from the kind mapping (service/worker→service, frontend→website, library→library, cli→tool, system→system), `spec.lifecycle: experimental`, `spec.owner: group:default/unknown` — Backstage rejects empty owner/lifecycle, so unknowns get sentinels, never empties, and once set they are never rewritten.
- **Passthrough**: everything outside the fences is never read for decisions and never rewritten. An existing unfenced `catalog-info.yaml` is refused, never overwritten.

The `backstage-catalog` skill is rewritten as the judgment layer over the verb (real owner, lifecycle, description, diff review). The `--knowledge backstage` system template's hardcoded `group:default/platform` becomes the shared `group:default/unknown` constant — a flagged generated-behavior change with an alignment test pinning template ↔ exporter agreement.

## Reviewer walkthrough

1. `src/generator/backstage_export.py` — `export_backstage`: create (full multi-doc emit) vs refresh (splice fenced regions only, byte-stable); typed extraction from `ParsedManifest`; line-presence validation for the fields Backstage requires, surfaced as warnings.
2. `src/cli/main.py` — `export` sub-app with the `backstage` command; exit 0 clean / 1 refused-or-warnings / 2 usage.
3. `src/templates/monorepo/catalog-info.yaml` — owner default swap (the one template change).
4. `.agents/skills/backstage-catalog/SKILL.md` — mechanical mapping removed; judgment procedure over the verb.
5. Tests — `tests/unit/generator/test_backstage_export.py`: fresh-emit shape, idempotence, declared+passthrough survival with in-fence edits reverted, unfenced refusal, kind→type mapping, system multi-doc with children, template/constant alignment, missing-required-line warnings. `tests/integration/test_export_command.py`: create → export → re-export unchanged → owner edit survives, on real generator output.
6. `docs/contracts/backstage-export.md` (+ indexes, agent guide, AGENTS.md source map) — the export contract, including the documented v1 limits.

## Correctness and invariants

Idempotence is structural: refresh only splices fenced regions, so export∘export is byte-stable (pinned by unit + integration tests). Declared fields can be "unknown" — per the design decision, unknowns get the most anonymous *valid* values rather than empties, and user-set values are never modified. Fail-closed inheritance from the markers module: malformed fences raise; unfenced files are refused. Documented v1 limits rather than silent gaps: children added after creation are not auto-inserted on refresh; `spec.type` is derived-at-creation then preserved; obsidian export is a named follow-up.

## Testing and QA

`make check` green (580 passed, 1 pre-existing skip). PR-tier evals pass (bootstrap CI cases, weight baselines — the template change is inside existing byte tolerance). 11 new unit tests + 1 end-to-end round trip.

## Risk / Rollout

The only generated-output change is the system template's owner sentinel (flagged; alignment-tested). Everything else is a new, opt-in verb: no existing flow calls it. The skill no longer hand-derives the mapping, so skill output can't drift from the verb.

Refs ENG-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DY47fSSZLXnZQCB8ceFkwN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DY47fSSZLXnZQCB8ceFkwN)_