### PR TITLE
Land audit stack after stacked-base merges

### DIFF
--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -19,15 +19,12 @@ current release line, or prepare a release PR. The full policy is
 2. Add the release entry to `CHANGELOG.md` and to `releaseNotes` in
    `website/src/site/content.ts`, and bump `defaultProjectMeta.latestVersion`
    there. Website tests fail when the current version has no release note.
-3. Update the dev-vars fallback in `website/wrangler.toml`
-   (`PROJECT_VERSION`, `RELEASE_URL`) and the `defaultConfig` fallback in
-   `website/scripts/render-release-config.ts`.
-4. Regenerate the committed golden fixture (procedure in
+3. Regenerate the committed golden fixture (procedure in
    `docs/contributing.md`). The version bump changes the `semantics` URL
    inside the fixture's `.kickstart/scaffold.json`, so `make check` fails
    with a golden-fixture diff until the fixture is regenerated — this is
    expected, not a template bug.
-5. Verify everything locally:
+4. Verify everything locally:
 
    ```bash
    make check
@@ -36,7 +33,7 @@ current release line, or prepare a release PR. The full policy is
    PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier full
    ```
 
-6. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit
+5. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit
    automatically when the `RELEASE_TAG_TOKEN` secret is configured (it
    re-runs `make release-check` first and never moves an existing tag).
    Without the secret the workflow fails — tag and push manually, pointing
@@ -48,11 +45,12 @@ current release line, or prepare a release PR. The full policy is
    git push origin vX.Y.Z
    ```
 
-7. Watch the release workflow: verify (incl. the website version-sync
+6. Watch the release workflow: verify (incl. the website version-sync
    gate) → package → binary (linux-x64, linux-arm64, macos-arm64 at
-   py3.14) → GitHub Release → website deploy. All jobs must be green,
-   including Deploy Website.
-8. Confirm the release is not stranded before reporting done:
+   py3.14) → GitHub Release → website deploy (which asserts the deployed
+   /healthz version equals the tag). All jobs must be green, including
+   Deploy Website.
+7. Confirm the release is not stranded before reporting done:
    `git ls-remote --tags origin` lists `vX.Y.Z`, the GitHub Release for
    the tag exists, and https://kickstart-cli.org shows the new version.
    A merged bump with no tag blocks all same-version retags until fixed.

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -22,7 +22,12 @@ current release line, or prepare a release PR. The full policy is
 3. Update the dev-vars fallback in `website/wrangler.toml`
    (`PROJECT_VERSION`, `RELEASE_URL`) and the `defaultConfig` fallback in
    `website/scripts/render-release-config.ts`.
-4. Verify everything locally:
+4. Regenerate the committed golden fixture (procedure in
+   `docs/contributing.md`). The version bump changes the `semantics` URL
+   inside the fixture's `.kickstart/scaffold.json`, so `make check` fails
+   with a golden-fixture diff until the fixture is regenerated — this is
+   expected, not a template bug.
+5. Verify everything locally:
 
    ```bash
    make check
@@ -30,25 +35,37 @@ current release line, or prepare a release PR. The full policy is
    make release-check TAG=vX.Y.Z
    ```
 
-5. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit
+6. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit
    automatically when the `RELEASE_TAG_TOKEN` secret is configured (it
    re-runs `make release-check` first and never moves an existing tag).
-   Without the secret, tag and push manually:
+   Without the secret the workflow fails — tag and push manually, pointing
+   the tag at the version-bump merge commit (never bare `git tag` on a
+   checkout whose HEAD may have advanced past the bump):
 
    ```bash
-   git tag -a vX.Y.Z -m "Release vX.Y.Z"
+   git tag -a vX.Y.Z -m "Release vX.Y.Z" <version-bump-merge-commit>
    git push origin vX.Y.Z
    ```
 
-6. Watch the release workflow: verify → package (PyPI) → binary
-   (linux-x64, linux-arm64, macos-arm64 at py3.14) → GitHub Release →
-   website deploy. All jobs must be green, including Deploy Website.
+7. Watch the release workflow: verify (incl. the website version-sync
+   gate) → package → binary (linux-x64, linux-arm64, macos-arm64 at
+   py3.14) → GitHub Release → website deploy. All jobs must be green,
+   including Deploy Website.
+8. Confirm the release is not stranded before reporting done:
+   `git ls-remote --tags origin` lists `vX.Y.Z`, the GitHub Release for
+   the tag exists, and https://kickstart-cli.org shows the new version.
+   A merged bump with no tag blocks all same-version retags until fixed.
 
 ## Same-Version Updates
 
 For docs, website copy, tests, or non-behavior fixes: do not bump the
 version. Merge, then retag the current release line onto the new `master`
-HEAD. Release assets are overwritten; PyPI publish skips existing artifacts.
+HEAD. Release assets are overwritten.
+
+Precondition: the current version must actually be tagged. A
+merged-but-untagged version bump makes every same-version retag fail
+`release-check` (each post-bump commit carries the pending version) — tag
+the pending version first.
 
 ## Rules
 

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -71,8 +71,11 @@ the pending version first.
 - Stable semver tags only (`vX.Y.Z`). Release candidates and build suffixes
   are rejected by CI.
 - Only tag commits already merged to `master`; the workflow enforces this.
-- PyPI artifacts are immutable. If a bad version shipped, fix forward with a
-  new patch version instead of retagging it.
+- There is no PyPI publish: the name `kickstart` on PyPI belongs to an
+  unrelated, abandoned project. The wheel/sdist attach to the GitHub
+  Release. Never document `pip install kickstart`.
+- If a bad version shipped, fix forward with a new patch version instead
+  of retagging it.
 - Do not start the tag step until `make release-check` passes locally.
 
 ## Report Back

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -33,6 +33,7 @@ current release line, or prepare a release PR. The full policy is
    make check
    cd website && bun run check && cd ..
    make release-check TAG=vX.Y.Z
+   PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier full
    ```
 
 6. Merge to `master`. The `Auto Tag Release` workflow tags the merge commit

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -11,8 +11,10 @@ name: Auto Tag Release
 #     not trigger other workflows (GitHub's anti-recursion rule), so the
 #     release pipeline would silently never run. The push therefore
 #     requires the RELEASE_TAG_TOKEN secret (fine-grained PAT with
-#     contents: read/write); without it this workflow skips loudly
-#     instead of creating a tag that goes nowhere.
+#     contents: read/write); without it this workflow FAILS, so a merged
+#     version bump can never sit untagged unnoticed (v0.4.3 was stranded
+#     for two weeks by a green "skip"). The failure email to the merge
+#     author is the alarm; it also catches a PAT that silently expired.
 
 on:
   push:
@@ -21,8 +23,11 @@ on:
     paths:
       - pyproject.toml
       - src/__init__.py
-  # Manual trigger for versions whose bump merged before this workflow
-  # existed (e.g. v0.4.2); the same gates apply.
+  # Manual trigger for versions whose bump merged while the workflow or
+  # its secret was missing; the same gates apply. Careful: a dispatch tags
+  # the checked-out HEAD of the selected ref. When master has advanced
+  # past the version bump, do NOT dispatch — tag the bump commit manually
+  # per docs/release-policy.md instead.
   workflow_dispatch:
 
 permissions:
@@ -61,21 +66,22 @@ jobs:
         if: steps.version.outputs.exists == 'false'
         run: make release-check TAG="${{ steps.version.outputs.tag }}"
 
+      # This step only executes when a new tag is genuinely needed (the
+      # paths trigger plus the exists guard above), so failing here has
+      # zero false positives — and unlike a notice on a green run, a
+      # failed run notifies the merge author.
       - name: Check tagging credentials
-        id: credentials
         if: steps.version.outputs.exists == 'false'
         env:
           RELEASE_TAG_TOKEN: ${{ secrets.RELEASE_TAG_TOKEN }}
         run: |
-          if [ -n "$RELEASE_TAG_TOKEN" ]; then
-            echo "ready=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::RELEASE_TAG_TOKEN is not configured. Skipping auto-tag for ${{ steps.version.outputs.tag }} — tags pushed with the default GITHUB_TOKEN cannot trigger the release workflow. Tag manually per docs/release-policy.md."
+          if [ -z "$RELEASE_TAG_TOKEN" ]; then
+            echo "::error::RELEASE_TAG_TOKEN is not configured — ${{ steps.version.outputs.tag }} is merged but cannot be auto-tagged, and tags pushed with the default GITHUB_TOKEN cannot trigger the release workflow. Tag manually per docs/release-policy.md, then configure the secret so the next bump tags itself."
+            exit 1
           fi
 
       - name: Create and push release tag
-        if: steps.version.outputs.exists == 'false' && steps.credentials.outputs.ready == 'true'
+        if: steps.version.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,8 @@ jobs:
           # macos-x64 is intentionally omitted: the macos-15-intel runner
           # schedules on arm64 hardware in this org, so PyInstaller fails with
           # IncompatibleBinaryArchError. This matches the release matrix, which
-          # dropped macos-x64 in v0.4.1 (PR #66); x64 macOS installs via PyPI.
+          # dropped macos-x64 in v0.4.1 (PR #66); x64 macOS installs from
+          # source or the release wheel (docs/install-binaries.md).
           - runner: macos-15
             platform: macos-arm64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,24 +154,29 @@ jobs:
 
           test -d /tmp/test-cli-tool
 
-      # Dogfood gate: kickstart must bootstrap a kickstart-like project that
-      # passes taste rules and its own `make check`. CI runs the headline
-      # python case; the full matrix stays a local eval (docs/evals.md).
+      # Dogfood gate, tier `pr` of the eval suite: the four fast bootstrap
+      # cases (taste rules + generated `make check`) plus the scaffold-weight
+      # baseline check against tests/fixtures/scaffold-weight-baselines.json.
+      # One entrypoint so CI and local runs agree (docs/evals.md); the full
+      # matrix runs weekly in Scheduled Evals via `--tier full`.
       - name: Restore bootstrap eval dependency cache
         uses: actions/cache@v4
         with:
-          path: /tmp/bootstrap-eval-cache
+          path: /tmp/kickstart-eval-cache
           key: bootstrap-eval-${{ runner.os }}-${{ hashFiles('src/stack/toolchain_versions.py', 'src/templates/python/**') }}
           restore-keys: |
             bootstrap-eval-${{ runner.os }}-
 
-      - name: Bootstrap eval (python CLI + full-extension service, TS worker, Rust CLI)
-        run: |
-          PYTHONPATH=$(pwd) poetry run python scripts/bootstrap_eval.py \
-            --cases python-cli-kickstart-like python-service typescript-worker rust-cli \
-            --output-root /tmp/bootstrap-eval \
-            --cache-root /tmp/bootstrap-eval-cache \
-            --report /tmp/bootstrap-eval.md
+      - name: Eval suite (tier pr)
+        run: PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier pr
+
+      - name: Upload eval reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-reports-pr
+          path: /tmp/kickstart-run-evals-*.md
+          retention-days: 7
 
       - name: Smoke test kickstart install subcommand
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,3 +282,22 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WEBSITE_API_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: bun run deploy:release
+
+      # Deployed-vs-source parity is otherwise unobservable: the site can
+      # serve a stale version for weeks with every check green. /healthz
+      # reports the served version; assert it matches the tag we released.
+      - name: Verify the deployed website serves this release
+        if: ${{ steps.website-deploy.outputs.ready == 'true' }}
+        run: |
+          EXPECTED="${GITHUB_REF_NAME#v}"
+          for attempt in 1 2 3 4 5; do
+            DEPLOYED=$(curl -fsSL https://kickstart-cli.org/healthz | python3 -c "import json,sys; print(json.load(sys.stdin).get('version',''))" || true)
+            if [ "$DEPLOYED" = "$EXPECTED" ]; then
+              echo "kickstart-cli.org serves v${DEPLOYED}."
+              exit 0
+            fi
+            echo "Attempt ${attempt}: deployed version '${DEPLOYED}' != '${EXPECTED}'; retrying in 15s..."
+            sleep 15
+          done
+          echo "::error::kickstart-cli.org still serves '${DEPLOYED}' instead of '${EXPECTED}' after deploy."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,12 +62,15 @@ jobs:
           bun install --frozen-lockfile
           bun run check
 
+  # No PyPI publish on purpose: the PyPI name "kickstart" belongs to an
+  # unrelated, abandoned 2011 project, so a publish step could only fail
+  # or mislead. The wheel/sdist attach to the GitHub Release instead. If
+  # the project ever gets a PyPI identity (rename or PEP 541 transfer),
+  # reintroduce publishing as a fail-loud step, not a skip-on-missing-token.
   package:
     name: Build Python Package
     runs-on: ubuntu-latest
     needs: verify
-    permissions:
-      id-token: write
 
     steps:
       - name: Checkout code
@@ -81,17 +84,6 @@ jobs:
 
       - name: Build package
         run: make package
-
-      - name: Publish to PyPI
-        if: ${{ !contains(github.ref_name, 'rc') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'alpha') }}
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          if [ -n "$POETRY_PYPI_TOKEN_PYPI" ]; then
-            poetry publish --no-interaction --skip-existing
-          else
-            echo "PYPI_API_TOKEN not set, skipping PyPI publish"
-          fi
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v4
@@ -205,15 +197,18 @@ jobs:
 
             The script downloads the matching binary archive, verifies its SHA-256, installs the binary payload under a stable directory, and exposes `kickstart` on `PATH`.
 
-            ### From PyPI
+            ### From source or wheel (platforms without a binary archive)
+
+            Do **not** `pip install kickstart` — that PyPI name belongs to an unrelated, abandoned 2011 project. Install from source, or from the wheel attached to this release:
 
             ```bash
-            pip install kickstart
+            pipx install git+https://github.com/${{ github.repository }}
+            pip install ./kickstart-*-py3-none-any.whl
             ```
 
             ### Manual binary install
 
-            Binary archives are attached for `linux-x64`, `linux-arm64`, and `macos-arm64` (Python 3.14). Other platforms install from PyPI. Pick the asset for your platform, extract it, and run `kickstart install` to place the binary payload in a user-writable directory and configure `PATH`:
+            Binary archives are attached for `linux-x64`, `linux-arm64`, and `macos-arm64` (Python 3.14). Pick the asset for your platform, extract it, and run `kickstart install` to place the binary payload in a user-writable directory and configure `PATH`:
 
             ```bash
             curl -L -o kickstart-linux-x64-py3.14.tar.gz "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/kickstart-linux-x64-py3.14.tar.gz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,21 @@ jobs:
       - name: Run checks
         run: make check
 
+      # The website version-sync test (content.ts <-> pyproject.toml) must
+      # gate the release BEFORE anything publishes; the website job below
+      # runs after the GitHub Release exists, which is too late to stop a
+      # desynced changelog from shipping.
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.5"
+
+      - name: Check website (version sync gate)
+        working-directory: website
+        run: |
+          bun install --frozen-lockfile
+          bun run check
+
   package:
     name: Build Python Package
     runs-on: ubuntu-latest
@@ -239,9 +254,15 @@ jobs:
         run: |
           if [ -n "$CLOUDFLARE_ACCOUNT_ID" ] && [ -n "$CLOUDFLARE_API_TOKEN" ]; then
             echo "ready=true" >> "$GITHUB_OUTPUT"
+          elif [ "$GITHUB_REPOSITORY" = "woud420/kickstart" ]; then
+            # On the canonical repo a missing credential means the public
+            # site silently stops tracking releases — fail instead of
+            # green-skipping (the pattern that stranded v0.4.3 untagged).
+            echo "::error::Cloudflare website credentials are not configured; the release website deploy cannot run. Configure the CLOUDFLARE_ACCOUNT_ID variable and CLOUDFLARE_WEBSITE_API_TOKEN secret."
+            exit 1
           else
             echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "Cloudflare website credentials are not configured; skipping website deploy."
+            echo "Cloudflare website credentials are not configured; skipping website deploy (fork)."
           fi
 
       - name: Deploy website with Alchemy

--- a/.github/workflows/scheduled-evals.yml
+++ b/.github/workflows/scheduled-evals.yml
@@ -53,3 +53,43 @@ jobs:
           name: bootstrap-eval-report
           path: /tmp/bootstrap-eval.md
           retention-days: 30
+
+  # A merged version bump whose tag never got pushed is a stranded release:
+  # master, the changelog, and generated manifests claim a version that users
+  # cannot install and whose semantics URL 404s. Auto Tag Release now fails
+  # loudly at bump time, but this weekly check also catches the strand modes
+  # that happen later: a tag pushed while the Release workflow failed, or a
+  # revoked/expired credential discovered only on the next release.
+  release-drift:
+    name: Release Drift Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify the current version is tagged and released
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if ! git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::pyproject.toml is ${VERSION} but tag v${VERSION} does not exist — the release is stranded. Tag the version-bump commit per docs/release-policy.md."
+            exit 1
+          fi
+          if ! gh api "repos/${GITHUB_REPOSITORY}/releases/tags/v${VERSION}" --silent; then
+            echo "::error::Tag v${VERSION} exists but has no GitHub Release — the release workflow likely failed. Re-run it for the tag."
+            exit 1
+          fi
+
+      # Every generated .kickstart/scaffold.json pins its semantics URL to
+      # the generating version's tag; a 404 here means every manifest cut
+      # from this source tree carries a dead contract link.
+      - name: Verify the manifest semantics URL resolves
+        run: |
+          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          URL="https://github.com/${GITHUB_REPOSITORY}/blob/v${VERSION}/docs/scaffold-contract.md"
+          if ! curl -fsSLo /dev/null "$URL"; then
+            echo "::error::Manifest semantics URL does not resolve: ${URL}"
+            exit 1
+          fi

--- a/.github/workflows/scheduled-evals.yml
+++ b/.github/workflows/scheduled-evals.yml
@@ -3,8 +3,13 @@ name: Scheduled Evals
 # Weekly canary against live toolchains. Generated projects resolve their
 # dependencies fresh, so template rot (new ruff/mypy/clippy releases, crate
 # MSRV bumps, registry changes) surfaces here within a week even when no PR
-# touches the templates. PRs gate the fast bootstrap cases; this run covers
-# the full matrix.
+# touches the templates. PRs gate eval tier `pr` (four fast bootstrap
+# cases + weight baselines); this run covers tier `full`: the whole
+# bootstrap matrix (python cli/lib/service/service-minimal, typescript
+# worker, rust cli, cpp service), weight baselines, determinism, and the
+# website-examples drift check. Go services and frontend scaffolds are not
+# yet bootstrap-validated here — extending the matrix is tracked on the
+# board — so rot in those templates does NOT surface within a week.
 
 on:
   schedule:
@@ -35,23 +40,18 @@ jobs:
         with:
           bun-version: "1.3.5"
 
-      - name: Full bootstrap eval (all cases, live dependencies)
-        run: |
-          PYTHONPATH=$(pwd) poetry run python scripts/bootstrap_eval.py \
-            --output-root /tmp/bootstrap-eval \
-            --cache-root /tmp/bootstrap-eval-cache \
-            --report /tmp/bootstrap-eval.md
+      # Tier `full` = full bootstrap matrix + weight baselines +
+      # determinism tests + website-examples drift check, from the same
+      # entrypoint CI and local runs use.
+      - name: Eval suite (tier full)
+        run: PYTHONPATH=$(pwd) poetry run python scripts/run_evals.py --tier full
 
-      - name: Website examples drift check
-        run: |
-          PYTHONPATH=$(pwd) poetry run python -m pytest tests/integration/test_website_examples.py -q
-
-      - name: Upload eval report
+      - name: Upload eval reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: bootstrap-eval-report
-          path: /tmp/bootstrap-eval.md
+          name: eval-reports-full
+          path: /tmp/kickstart-run-evals-*.md
           retention-days: 30
 
   # A merged version bump whose tag never got pushed is a stranded release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 Notable changes per release. The website release section
 (`website/src/site/content.ts`) carries the same entries and is
-test-enforced to include the current `pyproject.toml` version, so the
-public changelog cannot silently fall behind a release.
+test-enforced to include the current `pyproject.toml` version — in
+`bun run check`, per-PR CI, and the release workflow's verify job — so
+the website source cannot fall behind a version bump. Deployed-site
+parity is a release-time property: the site updates when the release
+tag's Deploy Website job runs, and the weekly release-drift check fails
+if a merged version ever sits untagged.
 
 Release mechanics live in [docs/release-policy.md](docs/release-policy.md).
 
@@ -29,7 +33,7 @@ but the development and release machinery around kickstart got materially better
   (`docs/decisions/headroom-benchmark-learnings.md`).
 - Test coverage: `make coverage` measures `src/` + `ci/` (88.1% baseline); a CI
   job uploads to Codecov (fail-soft without the token). The README leads with
-  CI, Release, Scheduled Evals, Codecov, latest-release, and PyPI badges.
+  CI, Release, Scheduled Evals, Codecov, and latest-release badges.
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LOG_RESET :=
 endif
 log = printf "$(LOG_COLOR)==>$(LOG_RESET) %s\n" "$(1)"
 
-.PHONY: help setup install run tests test-unit test-integration coverage typecheck lint format format-check type-hygiene template-audit check package binary build release-check clean
+.PHONY: help setup install run tests test-unit test-integration coverage typecheck lint format format-check type-hygiene import-hygiene template-audit check package binary build release-check clean
 
 help:
 	@echo "Usage:"
@@ -35,6 +35,7 @@ help:
 	@echo "  make format           Format source, tests, and CI Python with Ruff"
 	@echo "  make format-check     Check Ruff formatting without changing files"
 	@echo "  make type-hygiene     Check for loose Any/object-style type annotations"
+	@echo "  make import-hygiene   Check error classes are imported from src.utils.errors"
 	@echo "  make template-audit   Check template wiring inventory"
 	@echo "  make check            Run lint, typecheck, and tests"
 	@echo "  make package          Build wheel and source distribution"
@@ -87,11 +88,15 @@ type-hygiene:
 	@$(call log,Auditing type hygiene)
 	@$(PY) scripts/type_hygiene_audit.py
 
+import-hygiene:
+	@$(call log,Auditing import provenance)
+	@$(PY) scripts/import_hygiene_audit.py
+
 template-audit:
 	@$(call log,Auditing template wiring)
 	@$(PY) scripts/template_wiring_audit.py --strict
 
-check: lint typecheck type-hygiene template-audit tests
+check: lint typecheck type-hygiene import-hygiene template-audit tests
 
 package:
 	@$(call log,Building Python package)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Release history lives in [CHANGELOG.md](CHANGELOG.md) and on [kickstart-cli.org]
 
 ## Install
 
-One-line install of the latest release. Drops a launcher in `~/.local/bin/kickstart` and the binary payload in `~/.local/share/kickstart` (Linux x64/arm64 and macOS arm64; other platforms install from PyPI with `pip install kickstart`):
+One-line install of the latest release. Drops a launcher in `~/.local/bin/kickstart` and the binary payload in `~/.local/share/kickstart` (Linux x64/arm64 and macOS arm64; other platforms install from source, below):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/woud420/kickstart/master/scripts/install.sh | bash
@@ -56,10 +56,11 @@ Refresh in place against the newest release once installed:
 kickstart upgrade
 ```
 
-Or install from PyPI when published:
+On platforms without a binary archive (for example Intel macOS), install from source or from the wheel attached to each GitHub Release. Do **not** `pip install kickstart` — that PyPI name belongs to an unrelated, abandoned 2011 project:
 
 ```bash
-pip install kickstart
+pipx install git+https://github.com/woud420/kickstart          # from source
+pip install ./kickstart-<version>-py3-none-any.whl             # wheel from the Releases page
 ```
 
 ## Get Started
@@ -167,6 +168,6 @@ make package
 make binary
 ```
 
-kickstart supports Python `>=3.12,<3.15`. CI tests Python 3.12, 3.13, and 3.14 on Linux and macOS. Release builds attach Linux/macOS x64 and arm64 binary archives (`kickstart-<platform>-py<minor>.tar.gz`) for each supported Python minor.
+kickstart supports Python `>=3.12,<3.15`. CI tests Python 3.12, 3.13, and 3.14 on Linux and macOS. Release builds attach Python 3.14 binary archives (`kickstart-<platform>-py3.14.tar.gz`) for `linux-x64`, `linux-arm64`, and `macos-arm64`; other platforms use the source/wheel install path in [Install](#install).
 
 Current local eval evidence is tracked in [Local Evals](docs/evals.md). Reports are generated under `/tmp` or another scratch path and are not committed.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,7 +50,7 @@ make check
 ```
 
 Use `make package` to build the wheel/source distribution and `make binary` to build the local kickstart binary (a PyInstaller `--onedir` payload under `dist/kickstart/`).
-GitHub Actions tests Python 3.12, 3.13, and 3.14 on Linux and macOS, then release builds attach Python 3.14 binary archives (`kickstart-<platform>-py3.14.tar.gz`) for `linux-x64`, `linux-arm64`, and `macos-arm64`. Other platforms install from PyPI.
+GitHub Actions tests Python 3.12, 3.13, and 3.14 on Linux and macOS, then release builds attach Python 3.14 binary archives (`kickstart-<platform>-py3.14.tar.gz`) for `linux-x64`, `linux-arm64`, and `macos-arm64`. Other platforms install from source or from the wheel attached to each GitHub Release (see docs/install-binaries.md).
 
 ## Releases
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ The TypeScript Cloudflare Worker scaffold has a committed golden fixture at:
 - `tests/fixtures/golden/service-hello-worker-typescript-cloudflare-worker`
 - validated by `tests/integration/test_scaffold_golden.py`
 
-When intentional generator changes affect this scaffold, regenerate and review the fixture diff:
+When intentional generator changes affect this scaffold — including version bumps, which change the `semantics` URL inside the fixture's `.kickstart/scaffold.json` — regenerate and review the fixture diff:
 
 ```bash
 tmpdir=$(mktemp -d)
@@ -58,7 +58,7 @@ Release tags must be stable semantic versions like `v0.4.1`. The tag must match 
 
 Run `make release-check TAG=v0.4.1` before pushing a release tag.
 
-Use a new patch/minor/major version for behavior or installable output changes. For docs, website copy, tests, or other same-version fixes, retag the current release line after merge so CI updates the existing GitHub Release instead of creating a new version. On reused tags, GitHub Release assets are overwritten while PyPI publish skips already-existing package artifacts for that version.
+Use a new patch/minor/major version for behavior or installable output changes. For docs, website copy, tests, or other same-version fixes, retag the current release line after merge so CI updates the existing GitHub Release instead of creating a new version. On reused tags, GitHub Release assets are overwritten. Same-version retags only work while the current version is actually tagged — a merged-but-untagged version bump fails `release-check` on every retag until the pending version ships, so tag pending bumps first.
 
 See [Release Policy](release-policy.md) for the full contract.
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -4,5 +4,7 @@ This directory records durable project decisions for kickstart itself.
 
 - [CLI Framework Research](cli-framework-research.md): sourced recommendation for Rust, Python, and TypeScript CLI framework defaults.
 - [Kickstart Token Savings Evidence](kickstart-token-savings-evidence.md): measured determinism and token savings for scaffold generation.
+- [Headroom Benchmark Learnings](headroom-benchmark-learnings.md): adopt/defer reasoning behind the scaffold-weight baselines and the tiered eval runner.
+- [Scaffold Metadata Architecture Review](scaffold-metadata-architecture-review.md): drift-as-reconciliation review of scaffold.json; schema 4.0 roadmap and migration ordering.
 
 Use this directory for decisions that should survive beyond a single implementation PR.

--- a/docs/evals.md
+++ b/docs/evals.md
@@ -109,7 +109,30 @@ capability declared in `.kickstart/scaffold.json` must be exercised by at
 least one generated test (`capability-tests` rule). The eval exits non-zero
 when any case fails generation, taste, capability coverage, or `make check`.
 
-CI gates four cases on every PR (python CLI, full-extension python service,
-typescript worker, rust CLI); the `Scheduled Evals` workflow runs the full
-matrix plus the website-examples drift check weekly against live
-toolchains, so template rot surfaces within a week without slowing PRs.
+CI runs `run_evals.py --tier pr` on every PR (python CLI, full-extension
+python service, typescript worker, rust CLI, plus the weight-baseline
+check); the `Scheduled Evals` workflow runs `--tier full` weekly against
+live toolchains — the whole bootstrap matrix, weight baselines,
+determinism, and the website-examples drift check. Template rot in the
+bootstrap matrix surfaces within a week without slowing PRs. Honest
+coverage note: go services and frontend scaffolds are not yet in the
+bootstrap matrix (their generation shape and weight are guarded, their
+generated `make test` is not), so rot there does not surface weekly —
+extending the matrix is tracked on the board.
+
+## Scaffold Weight Baselines
+
+`tests/fixtures/scaffold-weight-baselines.json` pins each scaffold's file
+count and content bytes. `token_savings_eval.py --check-baselines` fails
+when a scaffold's file count changes at all or its bytes drift beyond
+±10% of the committed baseline — the regression guard for the
+token-efficiency promise, run per PR (tier `pr`) and weekly (tier `full`):
+
+```bash
+PYTHONPATH=$(pwd) poetry run python scripts/token_savings_eval.py --check-baselines
+PYTHONPATH=$(pwd) poetry run python scripts/token_savings_eval.py --update-baselines  # acknowledge deliberate changes
+```
+
+Re-baseline (`--update-baselines`) only for deliberate template changes,
+and commit the fixture diff in the same PR as the template change so the
+review sees the weight delta.

--- a/docs/install-binaries.md
+++ b/docs/install-binaries.md
@@ -7,7 +7,10 @@ Release tags publish a prebuilt kickstart binary as a `.tar.gz` archive for:
 - `macos-arm64`
 
 Each platform is built for Python `3.14`. Platforms outside this matrix
-(for example Intel macOS) install from PyPI with `pip install kickstart`.
+(for example Intel macOS) install from source
+(`pipx install git+https://github.com/woud420/kickstart`) or from the
+wheel attached to each GitHub Release. Do not `pip install kickstart`:
+the PyPI name belongs to an unrelated, abandoned 2011 project.
 
 ## Asset Names
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -21,16 +21,19 @@ make release-check TAG=v0.4.1
 Use a new version when generated behavior, installable output, public CLI behavior, or release assets change.
 
 1. Update `pyproject.toml` and `src/__init__.py:__version__` together.
-2. Add the release entry to `CHANGELOG.md` and `website/src/site/content.ts` (website tests fail when the current version has no release note).
-3. Merge the change to `master`.
-4. The `Auto Tag Release` workflow tags the merge commit with `vX.Y.Z` automatically when the `RELEASE_TAG_TOKEN` secret (fine-grained PAT, `contents: read/write`) is configured. It never moves an existing tag and only tags after `make release-check` passes. Without the secret it skips with a notice — tag and push manually instead:
+2. Add the release entry to `CHANGELOG.md` and `website/src/site/content.ts` (the website tests fail when the current version has no release note; they run in `bun run check`, per-PR CI, and the release workflow's verify job before anything publishes).
+3. Regenerate the committed golden fixture (procedure in [docs/contributing.md](contributing.md)) — the version bump changes the `semantics` URL inside the fixture's `.kickstart/scaffold.json`, so `make check` fails until the fixture matches.
+4. Merge the change to `master`.
+5. The `Auto Tag Release` workflow tags the merge commit with `vX.Y.Z` automatically when the `RELEASE_TAG_TOKEN` secret (fine-grained PAT, `contents: read/write`) is configured. It never moves an existing tag and only tags after `make release-check` passes. Without the secret the workflow **fails** (it used to skip on a green run, which stranded v0.4.3 untagged for two weeks) — tag and push manually instead, pointing the tag at the **version-bump merge commit**, not `master` HEAD, which may have advanced past the bump and would ship changes the changelog does not cover:
 
 ```bash
-git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git tag -a vX.Y.Z -m "Release vX.Y.Z" <version-bump-merge-commit>
 git push origin vX.Y.Z
 ```
 
 The tag push uses a PAT because tags pushed with the default `GITHUB_TOKEN` do not trigger the release workflow.
+
+6. Verify the release actually shipped before calling it done: `git ls-remote --tags origin` shows the new tag, the release workflow ran green end to end (including Deploy Website), and kickstart-cli.org shows the new version. The weekly `Scheduled Evals` workflow also runs a release-drift check that fails whenever `pyproject.toml` names a version with no matching tag or GitHub Release.
 
 The release workflow builds the Python package and Python 3.14 binary archives (`kickstart-<platform>-py3.14.tar.gz` for `linux-x64`, `linux-arm64`, and `macos-arm64`), publishes or updates the GitHub Release, and deploys the website with metadata for that tag.
 
@@ -38,7 +41,9 @@ The release workflow builds the Python package and Python 3.14 binary archives (
 
 For documentation, website copy, tests, or non-behavior fixes that should stay on the current version, do not create a new version number.
 
-Retag the current release line after the fix is merged. The release workflow updates the existing GitHub Release for that tag, overwrites GitHub Release assets, and refreshes generated release notes. PyPI publish uses `--skip-existing`, so existing package artifacts for that version are skipped (no overwrite).
+Retag the current release line after the fix is merged. The release workflow updates the existing GitHub Release for that tag, overwrites GitHub Release assets, and refreshes generated release notes.
+
+Caveat: a merged-but-untagged version bump blocks same-version retags. `release-check` compares the tag against `pyproject.toml` at the tagged commit, and every commit after the bump carries the new version — so no fix can reach the published release or the website until the pending version is tagged. Tag the pending version first.
 
 ## Website
 

--- a/docs/scaffold-contract.md
+++ b/docs/scaffold-contract.md
@@ -7,12 +7,16 @@ kickstart generates a stable project map for humans and agents. The goal is not 
 Every project type gets:
 
 - `AGENTS.md`: short agent map for where to look first.
+- `README.md`: project intent and first commands.
+- `Makefile` with a canonical `check` target (lint + typecheck + tests) that CI invokes.
 - `docs/architecture/`: structure, boundaries, and architecture notes.
 - `docs/contracts/`: project-specific public surface. For a service this may be HTTP, env vars, ports, and queues; for a CLI it may be commands, flags, config files, and exit codes; for a library it may be public APIs and package metadata.
 - `docs/operations/`: project-specific development, validation, packaging, deployment, and runbook notes.
 - `docs/decisions/`: durable architecture and implementation decisions.
 - `.kickstart/scaffold.json`: machine-readable scaffold metadata.
 - `.github/workflows/ci.yml`: per-language GitHub Actions workflow that runs `make check` (lint + typecheck + tests) on push and pull requests. The workflow is emitted for every service, CLI, library, and frontend; system scaffolds emit `build.yml`, `test.yml`, and `deploy.yml` at the same path instead.
+
+This list is the same baseline that `kickstart adopt --check` validates (`STANDARD_ARTIFACTS` in `src/generator/adoption.py`); a repo satisfying this document passes the check.
 
 There is no separate root architecture document. `docs/architecture/` is the canonical architecture location.
 
@@ -28,7 +32,7 @@ There is no separate root architecture document. `docs/architecture/` is the can
 - `project.entrypoint`: optional process entrypoint.
 - `project.operation_root`: optional use-case implementation root.
 - `project.src_root_files`: optional list of files expected directly under `src/`.
-- `execution.models`: how code runs, for example `container`, `cloudflare-worker`, `static-site`, `cli`, or `library`.
+- `execution.models`: which runtime-artifact shape the scaffold generated, for example `container`, `cloudflare-worker`, `static-site`, `cli`, or `library`. `execution` records which runtime-artifact files the scaffold generated, never how code behaves.
 - `execution.platforms`: where runtime artifacts are meant to run, for example `local`, `kubernetes`, `cloudflare-workers`, `static-host`, or `none`.
 - `artifacts`: emitted files and tool configs, for example `image: dockerfile`, `kubernetes: kustomize`, `kubernetes: helm`, `worker: wrangler`, `iac: terraform`, or `ci: github-actions`.
 - `provider.targets`: infrastructure providers targeted by generated IaC or platform config, for example `aws`, `gcp`, or `cloudflare`.

--- a/scripts/generated_make_test_eval.py
+++ b/scripts/generated_make_test_eval.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 import signal
 import subprocess
+import tempfile
 import time
 from typing import Literal, cast
 
@@ -349,13 +350,14 @@ def write_report(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run make targets across generated scaffolds.")
-    parser.add_argument("--output-root", type=Path, default=Path("/private/tmp/kickstart-scaffold-matrix"))
-    parser.add_argument("--report", type=Path, default=Path("reports/generated-make-test-eval.md"))
+    scratch = Path(tempfile.gettempdir())
+    parser.add_argument("--output-root", type=Path, default=scratch / "kickstart-scaffold-matrix")
+    parser.add_argument("--report", type=Path, default=scratch / "kickstart-generated-make-test-eval.md")
     parser.add_argument("--timeout-seconds", type=int, default=35)
     parser.add_argument("--workers", type=int, default=8)
     parser.add_argument("--target", default="test")
     parser.add_argument("--dependency-mode", choices=("network", "cached", "offline"), default="cached")
-    parser.add_argument("--cache-root", type=Path, default=Path("/private/tmp/kickstart-eval-cache"))
+    parser.add_argument("--cache-root", type=Path, default=scratch / "kickstart-eval-cache")
     parser.add_argument("--prewarm", action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--prewarm-workers", type=int, default=2)
     args = parser.parse_args()

--- a/scripts/import_hygiene_audit.py
+++ b/scripts/import_hygiene_audit.py
@@ -1,0 +1,96 @@
+"""Audit import provenance for the split error model.
+
+Exception classes live in `src.utils.errors`; `src.utils.error_handling`
+owns only the handling API (decorators, ErrorCollector, safe_* helpers).
+Because error_handling re-imports a few classes for its own use, importing
+an error class from it half-works: some names resolve, others raise
+ImportError only at import time. PR #81 merged green with exactly that
+mixed import and broke master. This audit turns the mistake into a lint
+failure: any name ending in ``Error`` imported from
+``src.utils.error_handling`` is flagged.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_ROOTS = ("src", "scripts", "ci", "tests")
+
+# Matches single-line and parenthesized multi-line import statements.
+IMPORT_STATEMENT_PATTERN = re.compile(
+    r"from\s+src\.utils\.error_handling\s+import\s+(\([^)]*\)|[^\n]*)",
+    re.MULTILINE,
+)
+ERROR_NAME_PATTERN = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*Error)\b")
+
+
+@dataclass(frozen=True)
+class ImportHygieneIssue:
+    """One error-class import from the wrong module."""
+
+    path: Path
+    line_number: int
+    name: str
+
+    def render(self) -> str:
+        """Return a compact command-line issue string."""
+        relative_path = self.path.relative_to(REPO_ROOT)
+        return (
+            f"{relative_path}:{self.line_number}: imports {self.name} from"
+            " src.utils.error_handling — error classes live in src.utils.errors"
+        )
+
+
+def main() -> int:
+    """Run the import hygiene audit."""
+    source_files = _python_source_files()
+    issues = _scan_files(source_files)
+
+    print(f"import hygiene source files: {len(source_files)}")
+    print(f"import hygiene issues: {len(issues)}")
+    for issue in issues:
+        print(issue.render())
+
+    return 1 if issues else 0
+
+
+def _python_source_files() -> tuple[Path, ...]:
+    """Return Python source, script, CI, and test files to audit."""
+    files: list[Path] = []
+    for root_name in SOURCE_ROOTS:
+        root = REPO_ROOT / root_name
+        if not root.exists():
+            continue
+        files.extend(
+            path
+            for path in root.rglob("*.py")
+            if "__pycache__" not in path.parts and not path.name.endswith(".tpl")
+        )
+    return tuple(sorted(path for path in files if path.name != "import_hygiene_audit.py"))
+
+
+def find_issues(source: str, path: Path) -> tuple[ImportHygieneIssue, ...]:
+    """Return every error-class name imported from error_handling in ``source``."""
+    issues: list[ImportHygieneIssue] = []
+    for match in IMPORT_STATEMENT_PATTERN.finditer(source):
+        line_number = source.count("\n", 0, match.start()) + 1
+        for name_match in ERROR_NAME_PATTERN.finditer(match.group(1)):
+            issues.append(
+                ImportHygieneIssue(path=path, line_number=line_number, name=name_match.group(1))
+            )
+    return tuple(issues)
+
+
+def _scan_files(files: tuple[Path, ...]) -> tuple[ImportHygieneIssue, ...]:
+    """Return all wrong-module error imports for the given files."""
+    issues: list[ImportHygieneIssue] = []
+    for path in files:
+        issues.extend(find_issues(path.read_text(encoding="utf-8"), path))
+    return tuple(issues)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/scaffold_matrix_eval.py
+++ b/scripts/scaffold_matrix_eval.py
@@ -15,6 +15,7 @@ import random
 import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Literal, TypeGuard, cast
 
 
@@ -831,8 +832,9 @@ def main() -> int:
     parser.add_argument("--max-components-per-project", type=int, default=9)
     parser.add_argument("--max-system-depth", type=int, default=1)
     parser.add_argument("--exclude-known-gaps", action="store_true")
-    parser.add_argument("--output-root", type=Path, default=Path("/private/tmp/kickstart-scaffold-matrix"))
-    parser.add_argument("--report", type=Path, default=Path("reports/scaffold-eval-120.md"))
+    scratch = Path(tempfile.gettempdir())
+    parser.add_argument("--output-root", type=Path, default=scratch / "kickstart-scaffold-matrix")
+    parser.add_argument("--report", type=Path, default=scratch / "kickstart-scaffold-eval-120.md")
     args = parser.parse_args()
 
     if args.max_components_per_project < 1:

--- a/scripts/token_savings_eval.py
+++ b/scripts/token_savings_eval.py
@@ -127,6 +127,22 @@ DEFAULT_CASES: tuple[ScaffoldCase, ...] = (
             "none",
         ),
     ),
+    ScaffoldCase(
+        slug="python-cli",
+        args=("create", "cli", "ops-cli", "--lang", "python"),
+    ),
+    ScaffoldCase(
+        slug="go-service",
+        args=("create", "service", "api-go", "--lang", "go"),
+    ),
+    ScaffoldCase(
+        slug="cpp-service",
+        args=("create", "service", "api-cpp", "--lang", "cpp"),
+    ),
+    ScaffoldCase(
+        slug="frontend",
+        args=("create", "frontend", "web-app"),
+    ),
 )
 
 

--- a/src/stack/toolchain_versions.py
+++ b/src/stack/toolchain_versions.py
@@ -4,6 +4,12 @@ Each constant is consumed by Jinja templates via the ``vars`` field of a
 ``TemplateConfig``. Keeping the pins here means a generated project's
 Dockerfile, package manifest, and CI workflow agree on a single version
 without having to chase string literals across templates.
+
+Scope: language toolchains only. Base images that are not language
+toolchains (cpp's ``gcc:14`` builder, react's ``nginx:1.27-alpine``
+runtime) stay pinned in their templates deliberately — nothing else in
+those scaffolds has to agree with them, so there is no cross-file drift
+for this module to prevent.
 """
 
 from typing import Final
@@ -17,6 +23,10 @@ POETRY_VERSION: Final[str] = "1.8.4"
 RUST_TOOLCHAIN: Final[str] = "1.88"
 RUST_DOCKER_TAG: Final[str] = "1.88-bookworm"
 GO_VERSION: Final[str] = "1.26"
+# Must provide at least GO_VERSION: generated go.mod requires >= GO_VERSION
+# and the builder runs with GOTOOLCHAIN defaulting to local, so a builder
+# image older than go.mod breaks every generated Go service container.
+GO_DOCKER_TAG: Final[str] = "1.26.2-bookworm"
 
 
 def toolchain_vars() -> dict[str, TemplateValue]:
@@ -33,4 +43,5 @@ def toolchain_vars() -> dict[str, TemplateValue]:
         "rust_toolchain": RUST_TOOLCHAIN,
         "rust_docker_tag": RUST_DOCKER_TAG,
         "go_version": GO_VERSION,
+        "go_docker_tag": GO_DOCKER_TAG,
     }

--- a/src/templates/go/Dockerfile.tpl
+++ b/src/templates/go/Dockerfile.tpl
@@ -1,4 +1,4 @@
-FROM golang:1.26.2-bookworm AS builder
+FROM golang:{{ go_docker_tag }} AS builder
 
 WORKDIR /app
 COPY . .

--- a/src/utils/error_handling.py
+++ b/src/utils/error_handling.py
@@ -22,6 +22,31 @@ from src.utils.types import ErrorContext, ErrorContextValue
 
 logger = logging.getLogger(__name__)
 
+# The handling API only. Exception classes live in `src.utils.errors` and
+# are deliberately absent: importing an error class from this module
+# half-worked (only the four classes imported above resolved), which is
+# exactly how PR #81 merged green and broke master. Import error classes
+# from `src.utils.errors`; `make check` enforces this via the import
+# hygiene audit.
+__all__ = [
+    "error_context",
+    "handle_file_operations",
+    "handle_template_operations",
+    "handle_directory_operations",
+    "handle_http_operations",
+    "safe_operation",
+    "safe_operation_context",
+    "ErrorCollector",
+    "format_error_message",
+    "log_operation_result",
+    "batch_operation_wrapper",
+    "validate_language_support",
+    "ensure_directory_exists",
+    "safe_binary_write",
+    "safe_file_write",
+    "safe_file_copy",
+]
+
 P = ParamSpec("P")
 R = TypeVar("R")
 T = TypeVar("T")

--- a/src/utils/fs.py
+++ b/src/utils/fs.py
@@ -3,6 +3,7 @@ import logging
 from jinja2 import Environment, FileSystemLoader, DictLoader, Template
 from jinja2.exceptions import TemplateError as Jinja2TemplateError, TemplateNotFound
 from src.utils.errors import TemplateError
+from src.utils.logger import warn
 from src.utils.types import MutableRenderVars, RenderValue, RenderVars
 
 logger = logging.getLogger(__name__)
@@ -147,7 +148,11 @@ def write_file(path: Path, template: Path | str, **vars: RenderValue) -> None:
         OSError: If file cannot be written
 
     Template rendering failures do not raise; they fall back to legacy
-    placeholder replacement.
+    placeholder replacement and emit a user-facing warning. The fallback
+    only substitutes ``{{NAME}}`` placeholders, so a template with real
+    Jinja syntax (blocks, conditionals) that fails to render ships its
+    source markup verbatim — the warning is the signal to inspect the
+    generated file.
     """
     render_vars = _with_legacy_variable_aliases(vars)
 
@@ -167,7 +172,11 @@ def write_file(path: Path, template: Path | str, **vars: RenderValue) -> None:
                 content = engine.render_template(str(relative_path), render_vars)
                 logger.debug(f"Successfully rendered Jinja2 template: {template}")
             except (TemplateError, FileNotFoundError) as e:
-                # Fallback to legacy placeholder replacement
+                # Fallback to legacy placeholder replacement. Surface it to
+                # the user: the generator's own render path raises on the
+                # same error, and a silent log-only fallback ships broken
+                # Jinja markup verbatim into the generated file.
+                warn(f"Template {template} failed to render as Jinja ({e}); wrote it with legacy {{{{NAME}}}} substitution only — inspect {path}")
                 logger.warning(f"Jinja2 templating failed for {template}, falling back to legacy: {e}")
                 content = template.read_text(encoding='utf-8')
                 content = _legacy_replace(content, render_vars)
@@ -179,7 +188,8 @@ def write_file(path: Path, template: Path | str, **vars: RenderValue) -> None:
                 content = engine.render_string(template, render_vars)
                 logger.debug("Successfully rendered Jinja2 string template")
             except TemplateError as e:
-                # Fallback to legacy placeholder replacement
+                # Same fallback for string templates; same user-facing signal.
+                warn(f"Inline template for {path} failed to render as Jinja ({e}); wrote it with legacy {{{{NAME}}}} substitution only")
                 logger.warning(f"Jinja2 string templating failed, falling back to legacy: {e}")
                 content = _legacy_replace(template, render_vars)
 

--- a/tests/fixtures/scaffold-weight-baselines.json
+++ b/tests/fixtures/scaffold-weight-baselines.json
@@ -3,6 +3,22 @@
     "content_bytes": 23323,
     "files": 41
   },
+  "cpp-service": {
+    "content_bytes": 6635,
+    "files": 16
+  },
+  "frontend": {
+    "content_bytes": 8704,
+    "files": 21
+  },
+  "go-service": {
+    "content_bytes": 6368,
+    "files": 21
+  },
+  "python-cli": {
+    "content_bytes": 11057,
+    "files": 25
+  },
   "python-lib": {
     "content_bytes": 6897,
     "files": 13

--- a/tests/integration/test_scaffold_contract_roundtrip.py
+++ b/tests/integration/test_scaffold_contract_roundtrip.py
@@ -1,0 +1,46 @@
+"""Every generated scaffold satisfies its own adoption check.
+
+docs/scaffold-contract.md, STANDARD_ARTIFACTS in src/generator/adoption.py,
+and what generators actually emit are three descriptions of the same ENG-9
+baseline. This test pins the round trip so the three legs cannot drift
+apart silently: one scaffold per project kind is generated into a temp
+directory and must report `complete: true` from the same read-only check
+that `kickstart adopt --check` runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.generator.adoption import inspect_repo
+from tests.integration.conftest import KickstartRunner
+
+ROUNDTRIP_CASES = (
+    ("python-service", ("create", "service", "api", "--lang", "python")),
+    ("typescript-worker", ("create", "service", "edge", "--lang", "typescript", "--runtime", "cloudflare-workers")),
+    ("python-lib", ("create", "lib", "shared-models", "--lang", "python")),
+    ("rust-cli", ("create", "cli", "ops-tool", "--lang", "rust")),
+    ("frontend", ("create", "frontend", "web-app")),
+    ("aws-kubernetes-system", ("create", "system", "platform", "--cloud", "aws", "--runtime", "kubernetes", "--knowledge", "none")),
+)
+
+
+@pytest.mark.parametrize(("slug", "args"), ROUNDTRIP_CASES, ids=[case[0] for case in ROUNDTRIP_CASES])
+def test_generated_scaffold_passes_adoption_check(
+    slug: str,
+    args: tuple[str, ...],
+    kickstart_run: KickstartRunner,
+    repo_root: Path,
+    tmp_path: Path,
+) -> None:
+    completed = kickstart_run(*args, "--root", str(tmp_path), cwd=repo_root, capture_output=True, text=True)
+    assert completed.returncode == 0, f"{slug} generation failed: {completed.stdout}{completed.stderr}"
+
+    project_name = args[2]
+    report = inspect_repo(tmp_path / project_name)
+
+    incomplete = [artifact for artifact in report.artifacts if not artifact.ok]
+    details = ", ".join(f"{artifact.path}: {artifact.issue or 'missing'}" for artifact in incomplete)
+    assert report.complete, f"{slug} scaffold fails its own adoption check: {details}"

--- a/tests/unit/scripts/test_import_hygiene_audit.py
+++ b/tests/unit/scripts/test_import_hygiene_audit.py
@@ -1,0 +1,56 @@
+"""The import hygiene audit catches error-class imports from the wrong module.
+
+PR #81 merged green while importing TemplateError from
+src.utils.error_handling (it lives in src.utils.errors) and broke master.
+These tests pin that failure class as a lint error.
+
+The banned import statement is always built by concatenation here so that
+this test file itself stays clean under the audit (the same trick
+type_hygiene_audit uses for its own patterns).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.import_hygiene_audit import find_issues
+
+FAKE_PATH = Path("/repo/src/example.py")
+BANNED_IMPORT = "from src.utils." + "error_handling import "
+
+
+def test_flags_error_class_from_error_handling() -> None:
+    source = BANNED_IMPORT + "TemplateError\n"
+    issues = find_issues(source, FAKE_PATH)
+    assert [issue.name for issue in issues] == ["TemplateError"]
+    assert issues[0].line_number == 1
+
+
+def test_flags_mixed_import_exactly_like_pr_81() -> None:
+    source = BANNED_IMPORT + "KickstartError, TemplateError\n"
+    issues = find_issues(source, FAKE_PATH)
+    assert sorted(issue.name for issue in issues) == ["KickstartError", "TemplateError"]
+
+
+def test_flags_parenthesized_multiline_import() -> None:
+    source = BANNED_IMPORT + "(\n    ErrorCollector,\n    FileOperationError,\n)\n"
+    issues = find_issues(source, FAKE_PATH)
+    assert [issue.name for issue in issues] == ["FileOperationError"]
+    assert issues[0].line_number == 1
+
+
+def test_allows_handling_api_imports() -> None:
+    source = BANNED_IMPORT + "ErrorCollector, safe_file_write\nfrom src.utils.errors import TemplateError\n"
+    assert find_issues(source, FAKE_PATH) == ()
+
+
+def test_reports_line_numbers_for_later_imports() -> None:
+    source = "import os\n\n" + BANNED_IMPORT + "DirectoryCreationError\n"
+    issues = find_issues(source, FAKE_PATH)
+    assert issues[0].line_number == 3
+
+
+def test_repo_is_currently_clean() -> None:
+    from scripts.import_hygiene_audit import _python_source_files, _scan_files
+
+    assert _scan_files(_python_source_files()) == ()

--- a/tests/unit/scripts/test_token_savings_eval.py
+++ b/tests/unit/scripts/test_token_savings_eval.py
@@ -144,3 +144,13 @@ def test_baselines_payload_round_trips_through_compare() -> None:
 def test_load_baselines_requires_existing_file(tmp_path: Path) -> None:
     with pytest.raises(BaselineError, match="missing; run with --update-baselines"):
         load_baselines(tmp_path / "absent.json")
+
+
+def test_every_default_case_has_a_committed_baseline() -> None:
+    """New weight-eval cases cannot land unguarded: the committed baseline
+    file must cover exactly the DEFAULT_CASES slugs (audit finding: the
+    python CLI flagship was measured but never baseline-guarded)."""
+    from scripts.token_savings_eval import BASELINES_PATH
+
+    baselines = json.loads(BASELINES_PATH.read_text(encoding="utf-8"))
+    assert sorted(baselines) == sorted(case.slug for case in DEFAULT_CASES)

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from src.utils.errors import KickstartError, TemplateError
@@ -62,3 +64,27 @@ def test_render_template_with_invalid_syntax_raises_kickstart_template_error(tmp
 
     assert isinstance(exc_info.value, KickstartError)
     assert exc_info.value.__cause__ is not None
+
+
+def test_write_file_with_broken_path_template_warns_and_uses_legacy_substitution(tmp_path):
+    template_path = tmp_path / "broken.txt"
+    template_path.write_text("Hello {{NAME}} {% if broken %}")
+    output_path = tmp_path / "output.txt"
+
+    with patch("src.utils.fs.warn") as mock_warn:
+        write_file(output_path, template_path, name="World")
+
+    assert output_path.read_text() == "Hello World {% if broken %}"
+    mock_warn.assert_called_once()
+    assert "legacy {{NAME}} substitution" in mock_warn.call_args.args[0]
+
+
+def test_write_file_with_broken_inline_template_warns_and_uses_legacy_substitution(tmp_path):
+    output_path = tmp_path / "output.txt"
+
+    with patch("src.utils.fs.warn") as mock_warn:
+        write_file(output_path, "Hello {{NAME}} {% if broken %}", name="World")
+
+    assert output_path.read_text() == "Hello World {% if broken %}"
+    mock_warn.assert_called_once()
+    assert "legacy {{NAME}} substitution" in mock_warn.call_args.args[0]

--- a/tests/unit/utils/test_fs.py
+++ b/tests/unit/utils/test_fs.py
@@ -67,6 +67,7 @@ def test_render_template_with_invalid_syntax_raises_kickstart_template_error(tmp
 
 
 def test_write_file_with_broken_path_template_warns_and_uses_legacy_substitution(tmp_path):
+    """ENG-154 regression: path templates must warn before legacy fallback."""
     template_path = tmp_path / "broken.txt"
     template_path.write_text("Hello {{NAME}} {% if broken %}")
     output_path = tmp_path / "output.txt"
@@ -80,6 +81,7 @@ def test_write_file_with_broken_path_template_warns_and_uses_legacy_substitution
 
 
 def test_write_file_with_broken_inline_template_warns_and_uses_legacy_substitution(tmp_path):
+    """ENG-154 regression: inline templates must warn before legacy fallback."""
     output_path = tmp_path / "output.txt"
 
     with patch("src.utils.fs.warn") as mock_warn:

--- a/website/alchemy.run.ts
+++ b/website/alchemy.run.ts
@@ -65,6 +65,20 @@ if (app.stage === "prod" && config.domain !== "") {
   });
 }
 
+// Deploying a site whose hero and release-notes links point at a
+// nonexistent GitHub release publishes 404s (exactly the stranded-v0.4.3
+// failure mode). Make "the release URL resolves" a deploy precondition
+// instead of a timing coincidence.
+if (app.stage === "prod") {
+  const releaseCheck = await fetch(config.releaseUrl, { method: "HEAD", redirect: "follow" });
+  if (!releaseCheck.ok) {
+    throw new Error(
+      `release URL does not resolve (HTTP ${releaseCheck.status}): ${config.releaseUrl} — ` +
+        "publish the release (tag + release workflow) before deploying the website.",
+    );
+  }
+}
+
 export const worker = await Worker("website", {
   name: workerName,
   entrypoint: "./src/index.ts",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,5 @@
 {
   "name": "kickstart-website",
-  "version": "0.4.2",
   "private": true,
   "type": "module",
   "packageManager": "bun@1.3.5",

--- a/website/scripts/render-release-config.ts
+++ b/website/scripts/render-release-config.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
 
+import { defaultProjectMeta } from "../src/site/content";
+
 interface ReleaseConfig {
   domain: string;
   output: string;
@@ -10,14 +12,17 @@ interface ReleaseConfig {
   version: string;
 }
 
-const defaultConfig: ReleaseConfig = {
+// No version or releaseUrl fallback literals here: the version comes from
+// --version, pyproject.toml, or GITHUB_REF_NAME, and resolution fails
+// loudly instead of silently deploying a stale hardcoded release. The
+// remaining defaults come from content.ts (the test-enforced source of
+// truth) or are deploy plumbing with no release-time meaning.
+const defaultConfig = {
   domain: "kickstart-cli.org",
   output: "wrangler.release.toml",
-  releaseUrl: "https://github.com/woud420/kickstart/releases/tag/v0.4.3",
-  repositoryUrl: "https://github.com/woud420/kickstart",
+  repositoryUrl: defaultProjectMeta.repositoryUrl,
   serviceName: "kickstart-site",
-  supportedFrom: "0.4.0",
-  version: "0.4.3",
+  supportedFrom: defaultProjectMeta.supportedFrom,
 };
 
 function argumentValue(args: string[], name: string): string | undefined {
@@ -65,9 +70,14 @@ export function resolveReleaseConfig(
   const repositoryUrl =
     argumentValue(args, "--repository-url") ?? repositoryUrlFromEnv(env) ?? defaultConfig.repositoryUrl;
   const versionFile = argumentValue(args, "--version-file") ?? "../pyproject.toml";
-  const version = trimVersionPrefix(
-    argumentValue(args, "--version") ?? versionFromPyproject(versionFile) ?? env.GITHUB_REF_NAME ?? defaultConfig.version,
-  );
+  const resolvedVersion =
+    argumentValue(args, "--version") ?? versionFromPyproject(versionFile) ?? env.GITHUB_REF_NAME;
+  if (resolvedVersion === undefined) {
+    throw new Error(
+      `cannot resolve the release version: pass --version, make ${versionFile} readable, or set GITHUB_REF_NAME`,
+    );
+  }
+  const version = trimVersionPrefix(resolvedVersion);
   const releaseUrl =
     argumentValue(args, "--release-url") ?? `${repositoryUrl}/releases/tag/v${version}`;
 

--- a/website/src/index.ts
+++ b/website/src/index.ts
@@ -13,7 +13,7 @@ interface Env {
 
 const PUBLIC_HOSTNAME = "kickstart-cli.org";
 const HSTS_HEADER_VALUE = "max-age=15552000";
-const SECURITY_TXT = `Contact: mailto:jm@polarcoordinates.org
+const SECURITY_TXT = `Contact: mailto:jim@polarcoordinates.org
 Expires: 2027-06-26T00:00:00Z
 Preferred-Languages: en
 Canonical: https://${PUBLIC_HOSTNAME}/.well-known/security.txt
@@ -111,7 +111,10 @@ export default {
     }
 
     if (url.pathname === "/healthz") {
-      return withSecurityHeaders(jsonResponse({ status: "ok", service }), url);
+      // Version in the health payload makes deployed-vs-source drift
+      // observable: the release pipeline asserts this equals the tag.
+      const version = stripVersionPrefix(env.PROJECT_VERSION ?? defaultProjectMeta.latestVersion);
+      return withSecurityHeaders(jsonResponse({ status: "ok", service, version }), url);
     }
 
     if (url.pathname === "/assets/site.css") {

--- a/website/tests/worker.test.ts
+++ b/website/tests/worker.test.ts
@@ -1,13 +1,19 @@
 import { describe, expect, it } from "vitest";
 
 import worker from "../src/index";
+import { defaultProjectMeta } from "../src/site/content";
 
 const defaultEnv = {
   SERVICE_NAME: "kickstart-site",
 };
 
+// The current version comes from content.ts (itself test-pinned to
+// pyproject.toml), so a release bump updates these assertions for free
+// instead of requiring four hand-edited version strings.
+const latestVersion = defaultProjectMeta.latestVersion;
+
 describe("kickstart website worker", () => {
-  it("returns health status", async () => {
+  it("returns health status with the served version", async () => {
     const request = new Request("https://example.test/healthz") as Parameters<typeof worker.fetch>[0];
 
     const response = await worker.fetch(request, defaultEnv);
@@ -16,6 +22,19 @@ describe("kickstart website worker", () => {
     expect(await response.json()).toEqual({
       status: "ok",
       service: "kickstart-site",
+      version: latestVersion,
+    });
+  });
+
+  it("reports the deployed version from Worker vars in /healthz", async () => {
+    const request = new Request("https://example.test/healthz") as Parameters<typeof worker.fetch>[0];
+
+    const response = await worker.fetch(request, { ...defaultEnv, PROJECT_VERSION: "v9.9.9" });
+
+    expect(await response.json()).toEqual({
+      status: "ok",
+      service: "kickstart-site",
+      version: "9.9.9",
     });
   });
 
@@ -52,7 +71,7 @@ describe("kickstart website worker", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toContain("text/plain");
-    expect(body).toContain("Contact: mailto:jm@polarcoordinates.org");
+    expect(body).toContain("Contact: mailto:jim@polarcoordinates.org");
     expect(body).toContain("Canonical: https://kickstart-cli.org/.well-known/security.txt");
   });
 
@@ -66,9 +85,9 @@ describe("kickstart website worker", () => {
     expect(response.headers.get("cache-control")).toBe("no-store");
     const html = await response.text();
     expect(html).toContain('<h1 id="hero-title">kickstart</h1>');
-    expect(html).toContain("/assets/site.css?v=0.4.3");
-    expect(html).toContain("/assets/site.js?v=0.4.3");
-    expect(html).toContain("v0.4.3");
+    expect(html).toContain(`/assets/site.css?v=${latestVersion}`);
+    expect(html).toContain(`/assets/site.js?v=${latestVersion}`);
+    expect(html).toContain(`v${latestVersion}`);
     expect(html).toContain("Sandbox bootstrap, tiered eval runner, coverage and badges");
     expect(html).toContain("Scaffold contract convergence");
   });
@@ -131,7 +150,7 @@ describe("kickstart website worker", () => {
   });
 
   it("serves script assets", async () => {
-    const request = new Request("https://example.test/assets/site.js?v=0.4.3") as Parameters<typeof worker.fetch>[0];
+    const request = new Request(`https://example.test/assets/site.js?v=${latestVersion}`) as Parameters<typeof worker.fetch>[0];
 
     const response = await worker.fetch(request, defaultEnv);
     const script = await response.text();

--- a/website/wrangler.toml
+++ b/website/wrangler.toml
@@ -2,9 +2,8 @@ name = "kickstart-site"
 main = "src/index.ts"
 compatibility_date = "2026-05-02"
 
-[vars]
-SERVICE_NAME = "kickstart-site"
-PROJECT_VERSION = "0.4.3"
-SUPPORTED_FROM_VERSION = "0.4.0"
-REPOSITORY_URL = "https://github.com/woud420/kickstart"
-RELEASE_URL = "https://github.com/woud420/kickstart/releases/tag/v0.4.3"
+# No [vars] block on purpose: release deploys render wrangler.release.toml
+# from pyproject.toml (scripts/render-release-config.ts), and local dev
+# falls back to defaultProjectMeta in src/site/content.ts, which is
+# test-pinned to pyproject.toml. A hand-maintained copy here was one more
+# version string that could (and did) go stale.


### PR DESCRIPTION
## Primary changes

Repair the audit stack's delivery topology. PRs #84–#87 were each merged into the preceding `audit/*` branch, so GitHub showed them as merged without their patches reaching `master`. This merge commit joins `origin/audit/05-docs-pypi` to current master at PR #95 and preserves both stacks.

The landed behavior includes:

- generator hardening: Go builder-image single source of truth, error-import provenance checks, and loud legacy-template fallback;
- eval wiring: the tiered runner in PR and scheduled CI, report artifacts, and deliberate combined scaffold-weight baselines;
- website/release hardening: observable deployed version, release-URL preflight, one version source of truth, and post-deploy version verification;
- distribution correction: remove the unrelated PyPI package as an installation/publishing path and retain GitHub source/wheel artifacts.

## Reviewer walkthrough

1. Merge shape: `5629d40` has parents current master `9c16fe4` and the audit tip `e320313`.
2. Conflict resolutions: `.agents/skills/cut-release/SKILL.md`, `.github/workflows/release.yml`, and `docs/scaffold-contract.md` preserve the docs-interface model while taking the audit stack's newer release and distribution behavior.
3. Generator safety: `src/stack/toolchain_versions.py`, `src/templates/go/Dockerfile.tpl`, `src/utils/{errors,error_handling,fs}.py`, and `scripts/import_hygiene_audit.py`.
4. CI/evals: `.github/workflows/{ci,scheduled-evals}.yml`, `scripts/{run_evals,token_savings_eval,scaffold_matrix_eval,generated_make_test_eval}.py`, and the regenerated weight baselines.
5. Website/release: `website/alchemy.run.ts`, release-config rendering, Worker health output/tests, Wrangler config, README/install docs, and `.github/workflows/release.yml`.
6. Coverage follow-up: `6f99bbd` behaviorally covers both loud legacy-template fallback paths in `tests/unit/utils/test_fs.py`.

## Correctness and invariants

The repair starts from current `master`; it does not promote an old audit branch over newer work. The merge keeps PRs #88–#95's docs projections, fences, planning, agent layer, tiered adoption, Backstage export, and CLI coverage.

PR #83 is already patch-equivalent on master; Git reports it with `-` under `git cherry`. The four subsequent audit patches report `+` before this merge and are introduced here. The three textual conflicts were resolved semantically, including removing an obsolete release-skill instruction to update website fallback literals that the audit intentionally eliminates.

The weight-baseline update is deliberate combined output: the docs-interface stack added the portable agent-layer files, while the audit stack expanded guarded profiles. No scratch reports or eval caches are committed.

## Testing and QA

- `make check`: green — Ruff, mypy, type hygiene, import hygiene, template audit, 622 tests.
- `make coverage`: green — 622 tests and 94.4% total coverage; both newly introduced warning paths are covered.
- `cd website && bun run check`: green — TypeScript plus 18 tests.
- `poetry run python -m pytest tests/integration/test_website_examples.py -q`: 4 passed.
- `poetry run python scripts/run_evals.py --tier pr`: green after deliberately regenerating the combined scaffold-weight baselines; bootstrap CI cases and baseline gate pass.
- `poetry run python scripts/run_evals.py --tier full`: baselines, determinism, website examples, and six bootstrap profiles pass. The generated C++ profile reaches `format-check` but this local machine has no `clang-format` executable; no C++ template changed in this repair, so this is classified as a local toolchain gap rather than a template regression.

## Risk / Rollout

The diff is broad because it restores four already-reviewed PRs, but new merge judgment is concentrated in three conflict resolutions and the combined baseline refresh. CI independently verifies the branch on the repository toolchain.

After merge, re-read ENG-154/155/157/158 against master and clean up the obsolete `audit/*` branches. This PR references the existing affected tickets directly; Linear now tracks the repair through the attached PR.

Resolves ENG-154
Resolves ENG-155
Resolves ENG-157
Refs ENG-158
Refs ENG-153
Refs ENG-160