### PR TITLE
Document the canonical local kickstart entrypoint

### DIFF
--- a/docs/install-binaries.md
+++ b/docs/install-binaries.md
@@ -106,6 +106,40 @@ If your filesystem doesn't allow symlinks (rare), `kickstart install` falls
 back to writing a tiny `#!/bin/sh` wrapper at the target path. The wrapper
 behaves identically for users.
 
+## Local Development Entrypoint
+
+This section is the maintainer-facing contract for what the `kickstart` command
+on `PATH` should resolve to, so a stale entrypoint can always be diagnosed and
+repaired.
+
+The canonical install is the one this document describes: a launcher at
+`~/.local/bin/kickstart` (symlink or `#!/bin/sh` wrapper) pointing into
+`~/.local/share/kickstart/current/kickstart`, owned by `kickstart install` and
+refreshed by `kickstart upgrade`. Nothing else should shadow it. In particular,
+ad-hoc shims in personal `bin` directories (for example
+`~/workspace/bin/kickstart`) are not supported: they bypass `kickstart
+upgrade`, go stale silently, and hide which binary owns the command. Delete
+them, or reduce them to a one-line `exec "$HOME/.local/bin/kickstart" "$@"`
+that cannot drift.
+
+To track the repo instead of a release (maintainer workflow), install the
+working copy as a tool so the entrypoint follows local changes:
+
+```bash
+uv tool install --editable /path/to/kickstart   # or: pipx install --editable
+```
+
+Diagnose the current entrypoint state at any time:
+
+```bash
+which -a kickstart        # every match on PATH, in resolution order
+kickstart install --check # source, destination, payload dir, PATH status
+```
+
+`which -a` showing more than one path, or `install --check` reporting a missing
+destination, means a shadowing shim or a stale install — repair with the steps
+above.
+
 ## Self-Update
 
 Once installed, refresh in place against the newest release:


### PR DESCRIPTION
## Primary changes

Document the canonical maintainer entrypoint for `kickstart`, explain why ad-hoc workspace shims are unsupported, and provide deterministic diagnosis and repair commands.

## Reviewer walkthrough

Review the new `Local Development Entrypoint` section in `docs/install-binaries.md`, especially the managed launcher paths, editable-install alternative, and `which -a` / `install --check` diagnostics.

## Correctness and invariants

The conflict resolution preserves current `master` guidance for the supported release matrix, Intel macOS, wheels, and the unrelated PyPI package. The change is documentation-only and does not alter runtime behavior.

## Testing and QA

- `git diff --check`
- `make check` using the existing project virtualenv: Ruff, mypy, type hygiene, import hygiene, template audit, and 622 tests passed

## Risk / Rollout

Low-risk documentation-only change. The machine-local broken shim was removed separately and the managed v0.4.3 launcher was verified healthy.

Refs ENG-10